### PR TITLE
Support deploy to Google App Engine

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,20 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+
+.git
+.gitignore
+Dockerfile
+public/css
+
+# Node.js dependencies:
+node_modules/

--- a/README.md
+++ b/README.md
@@ -81,16 +81,19 @@ A sample customization repo is provided at [nytimes/library-customization-exampl
 
 
 ## Deploying the app
-
-### Using Heroku
-
-Use this button to quickly deploy to Heroku:
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://nyti.ms/2CrT2y2)
-
-To set your app's `GOOGLE_APPLICATION_JSON`, `GOOGLE_CLIENT_ID`, and `GOOGLE_CLIENT_SECRET` in Heroku, [set up a Google service account](https://console.cloud.google.com/iam-admin/serviceaccounts) and [OAuth 2.0 client](https://developers.google.com/identity/protocols/OAuth2). Add *<your-heroku-app-url\>.com* as an authorized domain in the general OAuth consent screen setup and then add *http://<your-heroku-app-url\>.com/auth/redirect* as the callback url in the OAuth credential setup itself. Set up your service account with API access to Drive and Cloud Datastore.
+Wherever you deploy Library, you'll likely want to [set up a Google service account](https://console.cloud.google.com/iam-admin/serviceaccounts) and [OAuth 2.0 client](https://developers.google.com/identity/protocols/OAuth2) Set up your service account with API access to Drive and Cloud Datastore.
 
 If you wish to deploy Library with customizations, create a git repo with the files you would like to include. Set the `CUSTOMIZATION_GIT_REPO` environment variable to the cloning URL. Files in the repo and packages specified in the `package.json` will be included in your library installation.
+
+### with Heroku
+
+This button can quickly deploy to Heroku:
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://nyti.ms/2CrT2y2)
+
+Set your app's `GOOGLE_APPLICATION_JSON`, `GOOGLE_CLIENT_ID`, and `GOOGLE_CLIENT_SECRET` with values from the service account and Oauth client. Add *<your-heroku-app-url\>.com* as an authorized domain in the general OAuth consent screen setup and then add *http://<your-heroku-app-url\>.com/auth/redirect* as the callback url in the OAuth credential setup itself. 
+
+### with Google App Engine
+You can also deploy Library to GAE, using the included `app.yaml`. Note that you will need to enable billing on your GCP project in order to use Google App Engine. More detailed instructions are provided on the [demo site](https://nyt-library-demo.herokuapp.com/get-started/deploying-library-google-app-engine).
 
 ### Using Docker
 Library can be used as a base image for deployment using Docker. This allows you

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,2 @@
+runtime: nodejs10
+instance_class: F4

--- a/bin/install_customizations
+++ b/bin/install_customizations
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
+if [[ -f ./.env ]];
+  then
+    echo "sourcing env vars"
+    source ./.env
+fi
 
 echo "Checking for CUSTOMIZATION_GIT_REPO environment variable..."
-
 if ! [[ -z ${CUSTOMIZATION_GIT_REPO} ]];
   then
     echo "Cloning custom repo...";

--- a/bin/install_customizations
+++ b/bin/install_customizations
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 if [[ -f ./.env ]];
   then
-    echo "sourcing env vars"
+    echo "sourcing environment variables from .env"
     source ./.env
 fi
 
@@ -9,7 +9,7 @@ echo "Checking for CUSTOMIZATION_GIT_REPO environment variable..."
 if ! [[ -z ${CUSTOMIZATION_GIT_REPO} ]];
   then
     echo "Cloning custom repo...";
-    # remove cusotm to allow for cloning to that directory name
+    # remove custom to allow for cloning to that directory name
     rm -r ./custom;
     git clone $CUSTOMIZATION_GIT_REPO custom;
     echo "Installing custom packages...";

--- a/bin/update_gae_pkg
+++ b/bin/update_gae_pkg
@@ -4,20 +4,21 @@ const fs = require('fs')
 const path = require('path')
 
 const pkgPath = path.join(__dirname, '../package.json')
-// load the custom pkg json
+// load the custom/package.json
 let customPkg = { dependencies: {} }
 try {
   customPkg = require('../custom/package.json')
 } catch (err) {
-  console.warn('Could not load custom Pkg, aborting', err)
-  process.exit(1)
+  console.warn('Could not load custom package.json, will use default Library config', err)
 }
 // load the normal pkg json
 const pkg = require(pkgPath)
 
 const {dotenv} = pkg.devDependencies
+
 // update the start config to use .env, add as normal dep
 pkg.scripts.start = `node -r dotenv/config server/index`
 pkg.dependencies = Object.assign({}, pkg.dependencies, {dotenv}, customPkg.dependencies)
 
+// write the updates package.json to disk
 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 4))

--- a/bin/update_gae_pkg
+++ b/bin/update_gae_pkg
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+const pkgPath = path.join(__dirname, '../package.json')
+// load the custom pkg json
+let customPkg = { dependencies: {} }
+try {
+  customPkg = require('../custom/package.json')
+} catch (err) {
+  console.warn('Could not load custom Pkg, aborting', err)
+  process.exit(1)
+}
+// load the normal pkg json
+const pkg = require(pkgPath)
+
+const {dotenv} = pkg.devDependencies
+// update the start config to use .env, add as normal dep
+pkg.scripts.start = `node -r dotenv/config server/index`
+pkg.dependencies = Object.assign({}, pkg.dependencies, {dotenv}, customPkg.dependencies)
+
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 4))

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "watch": "concurrently \"nodemon --inspect=0.0.0.0 -r dotenv/config -e js,ejs server/index.js\" \"nodemon -e scss --watch styles --watch custom/styles -x npm run build\"",
     "test": "NODE_ENV=test mocha test/**/*.test.js -r ./test/utils/bootstrap.js --recursive --exit",
     "test:cover": "NODE_ENV=test nyc --include=server/** --reporter=html --reporter=text mocha test/**/*.test.js -r ./test/utils/bootstrap.js --recursive --exit",
-    "lint": "eslint ./server"
+    "lint": "eslint ./server",
+    "gcp-build": "./bin/install_customizations && npm run build && ./bin/update_gae_pkg"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description of Change
In addition to Heroku, we're adding documentation for deploying to GAE. The deploy pattern will be similar to the Heroku workflow, but requires a little more configuration on the GCP side. Those steps are documented [here](https://nyt-library-demo.herokuapp.com/get-started/deploying-library-google-app-engine).

### Motivation and Context
We want Library to be approachable to everyone, regardless of technical expertise, and be environment agnostic for custom deploys.

### Checklist
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] relevant documentation is changed and/or added

