### PR TITLE
Remove duplicate in .gitignore, ignore custom dir content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+NODE_ENV=development
+
+# Google oAuth credentials
+GOOGLE_CLIENT_ID=123456-abcdefg.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=abcxyz12345
+GCP_PROJECT_ID=library-demo-1234
+APPROVED_DOMAINS="nytimes.com,dailypennsylvanian.com" # comma separated list of approved access domains.
+SESSION_SECRET=supersecretvalue
+
+# Google app credential
+GOOGLE_APPLICATION_CREDENTIALS='./server/.auth.json'
+
+# Google drive Configuration
+DRIVE_TYPE=team # or folder, if using a folder instead of a team drive
+DRIVE_ID=0123456ABCDEF # the ID of your team's drive or shared folder. The string of random numbers and letters at the end of your team drive or folder url.
+
+# Your customized repo
+CUSTOMIZATION_GIT_REPO=

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ yarn-error.log*
 dump.rdb
 coverage
 .nyc_output
-coverage
 .eslintcache
 .npmrc*
 .vscode
+custom/
+!custom/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage
 .vscode
 custom/
 !custom/README.md
+server/.auth.json

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "scripts": {
     "start": "node server/index.js",
+    "start-standard": "./bin/install_customizations && npm run build && node -r dotenv/config server/index.js",
     "build": "node-sass --include-path custom/styles --include-path styles/partials --source-map public/css/style.css.map --source-map-contents styles/style.scss public/css/style.css",
     "debug": "node -r dotenv/config --inspect --debug-brk server/index.js",
     "watch": "concurrently \"nodemon --inspect=0.0.0.0 -r dotenv/config -e js,ejs server/index.js\" \"nodemon -e scss --watch styles --watch custom/styles -x npm run build\"",


### PR DESCRIPTION
### Description of Change
- Remove a duplicate in .gitignore
- Add `custom` directory to .gitignore list (excluded README.md) to avoid people committing their override files.

### Related Issue
N/A

### Motivation and Context
- Provide better control over project structure

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added

