### PR TITLE
Fix missing forwarded args in fetchAllFiles

### DIFF
--- a/server/docs.js
+++ b/server/docs.js
@@ -16,7 +16,7 @@ const supportedTypes = new Set(['document', 'spreadsheet', 'text/html'])
 exports.cleanName = (name = '') => {
   return name
     .trim()
-    .replace(/^(\d+[-–—_\s]*)([^\d\/\-^\s]+)/, '$2') // remove leading numbers and delimiters
+    .replace(/^(\d+[-–—_\s]*)([^\d\\/\-^\s]+)/, '$2') // remove leading numbers and delimiters
     .replace(/\s*\|\s*([^|]+)$/i, '')
     .replace(/\W+home$/i, '')
     .replace(/\.[^.]+$/, '') // remove file extensions

--- a/server/list.js
+++ b/server/list.js
@@ -124,7 +124,7 @@ async function fetchAllFiles({nextPageToken: pageToken, nextListSoFar: listSoFar
       driveType,
       nextListSoFar,
       nextPageToken,
-      nextParentIds: parentIds,
+      nextParentIds: parentIds
     })
   }
 
@@ -142,7 +142,7 @@ async function fetchAllFiles({nextPageToken: pageToken, nextListSoFar: listSoFar
       driveType,
       nextListSoFar,
       nextPageToken,
-      nextParentIds: folders.map((folder) => folder.id),
+      nextParentIds: folders.map((folder) => folder.id)
     })
   }
 


### PR DESCRIPTION
### Description of Change
parentIds wasn't being forwarded correctly to recursive call, and that would lead to errors on large directories

Additionally, update variable naming to make missing forwarded args more apparent

### Motivation and Context
While setting up library, it would throw exceptions caused by querying with an invalid page token. This fixes that issue

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- ~~[ ] tests are updated and/or added to cover new code~~
- [x] relevant documentation is changed and/or added