### PR TITLE
Pass args to recursive fetchAllFiles calls

### DIFF
--- a/server/list.js
+++ b/server/list.js
@@ -122,7 +122,9 @@ async function fetchAllFiles({nextPageToken: pageToken, listSoFar = [], parentId
     return fetchAllFiles({
       nextPageToken,
       listSoFar: combined,
-      drive
+      drive,
+      parentIds,
+      driveType
     })
   }
 


### PR DESCRIPTION
### Description of Change
@pfhayes's PR goes further but I unfortunately still got a number of 400 Bad Request responses from the Drive API related to the pageToken parameter.

My PR just corrects two definite bugs where parameters are not passed down through recursive calls to the fetchAllFiles methods. Without these changes:

1. When building a tree for a `shared` folder, the driveType 'reverts' back to `team` when not passed through because that is the default parameter.
2. Without passing parentIds through, requests fail because it is trying to make a request that the pageToken is not valid for.

### Motivation and Context
The tree fails to update for shared folder driveTypes.

Note that the library still fails for large trees (a deeply nested hierarchy). I'm currently working around this locally by changing Ln 140 to: `  if (folders.length > 0 && folders.length < 100) {`

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes (or more accurately, the same 4 tests are failing as _before_ I made these changes (on Windows).
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [o] tests are updated and/or added to cover new code
- [o] relevant documentation is changed and/or added

