### PR TITLE
Correct path to .auth.json in warning message

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -10,9 +10,9 @@ const log = require('./logger')
 
 let authClient = null
 
-// In local development, look for an auth.json file.
+// In local development, look for an .auth.json file.
 if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && process.env.NODE_ENV === 'development') {
-  log.warn('GOOGLE_APPLICATION_CREDENTIALS was undefined, using default ./auth.json credentials file...')
+  log.warn('GOOGLE_APPLICATION_CREDENTIALS was undefined, using default ./.auth.json credentials file...')
   process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(__dirname, '.auth.json')
 }
 


### PR DESCRIPTION
### Description of Change

A warning message displays the incorrect path to .auth.json. This fixes it.

### Related Issue

None.

### Motivation and Context

Avoid typos.

### Checklist

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added
