### PR TITLE
Skip auth for static asset requests (fixes #3)

### DIFF
--- a/test/functional/userAuth.test.js
+++ b/test/functional/userAuth.test.js
@@ -38,6 +38,15 @@ describe('Authentication', () => {
           assert.equal(res.text, 'Found. Redirecting to /login')
         })
     })
+
+    it('should not redirect to login for static asset requests', () => {
+      return request(app)
+        .get('/assets/css/style.css')
+        .expect(200)
+        .then((res) => {
+          assert.equal(res.headers['content-type'], 'text/css; charset=UTF-8')
+        })
+    })
   })
 
   describe('when logged in', () => {


### PR DESCRIPTION
### Description of Change
This PR changes the default export of `server/index.js`. Instead of exporting `app` directly, it now exports a higher-order app that behaves as follows:

1. It handles static asset requests via `express.static`, skipping all middleware except the content security policy.
2. It delegates all other requests to the main app.

### Related Issue
See #3 

### Motivation and Context
@isaacwhite I think either solution you outlined in the issue description would have worked well, but this approach required fewer changes to the existing codebase and is probably simpler to maintain. Do you have any security concerns about serving static assets to logged-out users? I couldn't think of any, but I'm just getting familiar with the project and may have missed something important.

### Checklist
- [ ] ~~Ran `npm run lint` and updated code style accordingly~~
  The lint task was failing when I cloned the repo — I'm happy to fix it but I don't want to make more changes than necessary without someone reviewing this first!
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added