### PR TITLE
Preserve deep links into Google docs

### DIFF
--- a/server/formatter.js
+++ b/server/formatter.js
@@ -81,11 +81,10 @@ function normalizeHtml(html) {
 
       const decoded = qs.unescape(redirectUrl)
       const [isDoc, docId] = decoded.match(/docs\.google\.com.+\/d\/([^/]+)/i) || []
-      const [deepLink = ''] = decoded.match(/(?<=heading([^/]+))(.*)/i) || []
+      const [deepLink = ''] = decoded.match(/(?<=#heading=)([^/]+)/i) || []
 
       const {path: libraryPath} = isDoc ? list.getMeta(docId) || {} : {}
-      // Always include the deep link as part of the string; default will be empty
-      const libraryDeepLink = libraryPath && `${libraryPath}#${deepLink}`
+      const libraryDeepLink = deepLink && libraryPath ? `${libraryPath}#${deepLink}` : libraryPath
 
       $(el).attr('href', libraryDeepLink || decoded)
     }

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -81,8 +81,9 @@ function normalizeHtml(html) {
 
       const decoded = qs.unescape(redirectUrl)
       const [isDoc, docId] = decoded.match(/docs\.google\.com.+\/d\/([^/]+)/i) || []
+      const [deepLink] = decoded.match(/#heading([^/+])(.*)/i) || []
 
-      const {path: libraryPath} = isDoc ? list.getMeta(docId) || {} : {}
+      const { path: libraryPath } = isDoc ? (deepLink ? list.getMeta(docId) + deepLink : list.getMeta(docId) || {}) : {}
 
       $(el).attr('href', libraryPath || decoded)
     }

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -81,11 +81,13 @@ function normalizeHtml(html) {
 
       const decoded = qs.unescape(redirectUrl)
       const [isDoc, docId] = decoded.match(/docs\.google\.com.+\/d\/([^/]+)/i) || []
-      const [deepLink] = decoded.match(/#heading([^/+])(.*)/i) || []
+      const [deepLink = ''] = decoded.match(/(?<=heading([^/]+))(.*)/i) || []
 
-      const { path: libraryPath } = isDoc ? (deepLink ? list.getMeta(docId) + deepLink : list.getMeta(docId) || {}) : {}
+      const {path: libraryPath} = isDoc ? list.getMeta(docId) || {} : {}
+      // Always include the deep link as part of the string; default will be empty
+      const libraryDeepLink = libraryPath && `${libraryPath}#${deepLink}`
 
-      $(el).attr('href', libraryPath || decoded)
+      $(el).attr('href', libraryDeepLink || decoded)
     }
 
     return el


### PR DESCRIPTION
### Description of Change
Check if a link to a Google document (docs.google.com) contains a deep link to a specific sub-section (heading). If so, append the deep link to the document url.

### Related Issue
#24 

### Motivation and Context
As @abstrctn (👋!) noted in his issue, a link to a specific heading in a Google doc is currently stripped from the link added to the Library page, so the user is directed to the Google doc generally instead of the specified heading in that document. 

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [X] PR has a description and all contributors/stakeholder are noted/cc'ed
~- [ ] tests are updated and/or added to cover new code~
~- [ ] relevant documentation is changed and/or added~ 

