### PR TITLE
fixes #33 adds TRUST_PROXY environment variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1145,6 +1145,11 @@
         "callsites": "^0.2.0"
       }
     },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+    },
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
@@ -1772,6 +1777,14 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "decache": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.5.1.tgz",
+      "integrity": "sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==",
+      "requires": {
+        "callsite": "^1.0.0"
       }
     },
     "decamelize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1145,11 +1145,6 @@
         "callsites": "^0.2.0"
       }
     },
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-    },
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
@@ -1777,14 +1772,6 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
-      }
-    },
-    "decache": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/decache/-/decache-4.5.1.tgz",
-      "integrity": "sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==",
-      "requires": {
-        "callsite": "^1.0.0"
       }
     },
     "decamelize": {
@@ -3013,7 +3000,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3037,13 +3025,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3060,19 +3050,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3203,7 +3196,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3217,6 +3211,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3233,6 +3228,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3241,13 +3237,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3268,6 +3266,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3356,7 +3355,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3370,6 +3370,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3465,7 +3466,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3507,6 +3509,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3528,6 +3531,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3576,13 +3580,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "concurrently": "^3.6.1",
+    "decache": "^4.5.1",
     "dotenv": "^4.0.0",
     "eslint": "^3.19.0",
     "eslint-config-standard": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "concurrently": "^3.6.1",
-    "decache": "^4.5.1",
     "dotenv": "^4.0.0",
     "eslint": "^3.19.0",
     "eslint-config-standard": "^10.2.1",

--- a/server/index.js
+++ b/server/index.js
@@ -25,10 +25,7 @@ const {preload, postload} = allMiddleware
 // and redirect urls if it sees indications that the request
 // passed through a proxy and was originally sent using https
 if ((process.env.TRUST_PROXY || '').toUpperCase() === 'TRUE') {
-  if (process.env.TRUST_PROXY.toUpperCase() === 'TRUE') {
-    // console.log('TRUST_PROXY environment variable set to true, enabling "trust proxy" in app')
-    app.enable('trust proxy')
-  }
+  app.enable('trust proxy')
 }
 
 app.set('view engine', 'ejs')

--- a/server/index.js
+++ b/server/index.js
@@ -83,9 +83,9 @@ postload.forEach((middleware) => app.use(middleware))
 // error handler for rendering the 404 and 500 pages, must go last
 app.use(errorPages)
 
-// If we are testing, we don't need to listen on port 3000
+// If we are called directly, listen on port 3000, otherwise don't
 
-if (process.env.NODE_ENV !== 'test') {
+if (require.main === module) {
   app.listen(parseInt(process.env.PORT || '3000', 10))
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -25,12 +25,11 @@ const {preload, postload} = allMiddleware
 // and redirect urls if it sees indications that the request
 // passed through a proxy and was originally sent using https
 if ('TRUST_PROXY' in process.env) {
-  if (process.env.TRUST_PROXY.toUpperCase() === "TRUE"){
+  if (process.env.TRUST_PROXY.toUpperCase() === 'TRUE') {
     // console.log('TRUST_PROXY environment variable set to true, enabling "trust proxy" in app')
-    app.enable("trust proxy")
+    app.enable('trust proxy')
   }
 }
-
 
 app.set('view engine', 'ejs')
 app.set('views', path.join(__dirname, '../layouts'))
@@ -89,6 +88,5 @@ app.use(errorPages)
 if (process.env.NODE_ENV !== 'test') {
   app.listen(parseInt(process.env.PORT || '3000', 10))
 }
-
 
 module.exports = app

--- a/server/index.js
+++ b/server/index.js
@@ -24,7 +24,7 @@ const {preload, postload} = allMiddleware
 // The trust proxy flag tells the app to use https for links
 // and redirect urls if it sees indications that the request
 // passed through a proxy and was originally sent using https
-if ('TRUST_PROXY' in process.env) {
+if ((process.env.TRUST_PROXY || '').toUpperCase() === 'TRUE') {
   if (process.env.TRUST_PROXY.toUpperCase() === 'TRUE') {
     // console.log('TRUST_PROXY environment variable set to true, enabling "trust proxy" in app')
     app.enable('trust proxy')

--- a/server/index.js
+++ b/server/index.js
@@ -21,6 +21,17 @@ const app = express()
 
 const {preload, postload} = allMiddleware
 
+// The trust proxy flag tells the app to use https for links
+// and redirect urls if it sees indications that the request
+// passed through a proxy and was originally sent using https
+if ('TRUST_PROXY' in process.env) {
+  if (process.env.TRUST_PROXY.toUpperCase() === "TRUE"){
+    // console.log('TRUST_PROXY environment variable set to true, enabling "trust proxy" in app')
+    app.enable("trust proxy")
+  }
+}
+
+
 app.set('view engine', 'ejs')
 app.set('views', path.join(__dirname, '../layouts'))
 
@@ -72,6 +83,12 @@ postload.forEach((middleware) => app.use(middleware))
 
 // error handler for rendering the 404 and 500 pages, must go last
 app.use(errorPages)
-app.listen(parseInt(process.env.PORT || '3000', 10))
+
+// If we are testing, we don't need to listen on port 3000
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(parseInt(process.env.PORT || '3000', 10))
+}
+
 
 module.exports = app

--- a/test/functional/trustProxy.test.js
+++ b/test/functional/trustProxy.test.js
@@ -4,33 +4,23 @@ const request = require('supertest')
 const {assert} = require('chai')
 const sinon = require('sinon')
 const express = require('express')
-const decache = require('decache')
-
-const userInfo = {
-  emails: [{value: 'test.user@test.com'}],
-  id: '10',
-  userId: '10',
-  _json: {domain: 'test.com'}
-}
 
 describe('Trust Proxy', () => {
   describe('when trust proxy env is not true', () => {
     before(() => sinon.stub(express.request, 'isAuthenticated').returns(false))
-    beforeEach(() => decache('../../server/index'))
+    beforeEach(() => delete require.cache[require.resolve('../../server/index')])
     after(() => sinon.restore())
     // app moved inside tests so that it can be recreated later with different
     // environment variables setup.
     const app = require('../../server/index')
 
-
     it('redirect should be for http with no headers', () => {
-
       return request(app)
         .get('/login')
         .expect(302) // expect user to be found
         .then((res) => {
           assert(res.redirect)
-          assert.include(res.headers.location, "redirect_uri=http%3A",'Redirect URI is http')
+          assert.include(res.headers.location, 'redirect_uri=http%3A', 'Redirect URI is http')
         })
     })
 
@@ -41,36 +31,33 @@ describe('Trust Proxy', () => {
         .expect(302) // expect user to be found
         .then((res) => {
           assert(res.redirect)
-          assert.include(res.headers.location, "redirect_uri=http%3A",'Redirect URI is http')
+          assert.include(res.headers.location, 'redirect_uri=http%3A', 'Redirect URI is http')
         })
     })
-    //app.server.close()
+    // app.server.close()
   })
 
   describe('when trust proxy env is set to true', () => {
     before(() => sinon.stub(express.request, 'isAuthenticated').returns(false))
-    beforeEach(() => decache('../../server/index'))
+    beforeEach(() => delete require.cache[require.resolve('../../server/index')])
     after(() => sinon.restore())
     // app moved inside tests so that it can be recreated later with different
     // environment variables setup.
 
-
-
-
     it('redirect should be for http with no headers', () => {
-      process.env.TRUST_PROXY = "true"
+      process.env.TRUST_PROXY = 'true'
       const app = require('../../server/index')
       return request(app)
         .get('/login')
         .expect(302) // expect user to be found
         .then((res) => {
           assert(res.redirect)
-          assert.include(res.headers.location, "redirect_uri=http%3A",'Redirect URI is http')
+          assert.include(res.headers.location, 'redirect_uri=http%3A', 'Redirect URI is http')
         })
     })
 
     it('redirect should be for https with headers and env set', () => {
-      process.env.TRUST_PROXY = "true"
+      process.env.TRUST_PROXY = 'true'
       const app = require('../../server/index.js')
       return request(app)
         .get('/login')
@@ -78,10 +65,8 @@ describe('Trust Proxy', () => {
         .expect(302) // expect user to be found
         .then((res) => {
           assert(res.redirect)
-          assert.include(res.headers.location, "redirect_uri=https%3A",'Redirect URI is https')
+          assert.include(res.headers.location, 'redirect_uri=https%3A', 'Redirect URI is https')
         })
     })
   })
-
-
 })

--- a/test/functional/trustProxy.test.js
+++ b/test/functional/trustProxy.test.js
@@ -20,7 +20,7 @@ describe('Trust Proxy', () => {
     after(() => sinon.restore())
     // app moved inside tests so that it can be recreated later with different
     // environment variables setup.
-    var app = require('../../server/index')
+    const app = require('../../server/index')
 
 
     it('redirect should be for http with no headers', () => {
@@ -59,7 +59,7 @@ describe('Trust Proxy', () => {
 
     it('redirect should be for http with no headers', () => {
       process.env.TRUST_PROXY = "true"
-      var app = require('../../server/index')
+      const app = require('../../server/index')
       return request(app)
         .get('/login')
         .expect(302) // expect user to be found
@@ -71,7 +71,7 @@ describe('Trust Proxy', () => {
 
     it('redirect should be for https with headers and env set', () => {
       process.env.TRUST_PROXY = "true"
-      var app = require('../../server/index.js')
+      const app = require('../../server/index.js')
       return request(app)
         .get('/login')
         .set('X-Forwarded-Proto', 'https')

--- a/test/functional/trustProxy.test.js
+++ b/test/functional/trustProxy.test.js
@@ -47,7 +47,7 @@ describe('Trust Proxy', () => {
     //app.server.close()
   })
 
-  describe('when trust proxy env is not true', () => {
+  describe('when trust proxy env is set to true', () => {
     before(() => sinon.stub(express.request, 'isAuthenticated').returns(false))
     beforeEach(() => decache('../../server/index'))
     after(() => sinon.restore())

--- a/test/functional/trustProxy.test.js
+++ b/test/functional/trustProxy.test.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const request = require('supertest')
+const {assert} = require('chai')
+const sinon = require('sinon')
+const express = require('express')
+const decache = require('decache')
+
+const userInfo = {
+  emails: [{value: 'test.user@test.com'}],
+  id: '10',
+  userId: '10',
+  _json: {domain: 'test.com'}
+}
+
+describe('Trust Proxy', () => {
+  describe('when trust proxy env is not true', () => {
+    before(() => sinon.stub(express.request, 'isAuthenticated').returns(false))
+    beforeEach(() => decache('../../server/index'))
+    after(() => sinon.restore())
+    // app moved inside tests so that it can be recreated later with different
+    // environment variables setup.
+    var app = require('../../server/index')
+
+
+    it('redirect should be for http with no headers', () => {
+
+      return request(app)
+        .get('/login')
+        .expect(302) // expect user to be found
+        .then((res) => {
+          assert(res.redirect)
+          assert.include(res.headers.location, "redirect_uri=http%3A",'Redirect URI is http')
+        })
+    })
+
+    it('redirect should be for http with headers but env not set', () => {
+      return request(app)
+        .get('/login')
+        .set('X-Forwarded-Proto', 'https')
+        .expect(302) // expect user to be found
+        .then((res) => {
+          assert(res.redirect)
+          assert.include(res.headers.location, "redirect_uri=http%3A",'Redirect URI is http')
+        })
+    })
+    //app.server.close()
+  })
+
+  describe('when trust proxy env is not true', () => {
+    before(() => sinon.stub(express.request, 'isAuthenticated').returns(false))
+    beforeEach(() => decache('../../server/index'))
+    after(() => sinon.restore())
+    // app moved inside tests so that it can be recreated later with different
+    // environment variables setup.
+
+
+
+
+    it('redirect should be for http with no headers', () => {
+      process.env.TRUST_PROXY = "true"
+      var app = require('../../server/index')
+      return request(app)
+        .get('/login')
+        .expect(302) // expect user to be found
+        .then((res) => {
+          assert(res.redirect)
+          assert.include(res.headers.location, "redirect_uri=http%3A",'Redirect URI is http')
+        })
+    })
+
+    it('redirect should be for https with headers and env set', () => {
+      process.env.TRUST_PROXY = "true"
+      var app = require('../../server/index.js')
+      return request(app)
+        .get('/login')
+        .set('X-Forwarded-Proto', 'https')
+        .expect(302) // expect user to be found
+        .then((res) => {
+          assert(res.redirect)
+          assert.include(res.headers.location, "redirect_uri=https%3A",'Redirect URI is https')
+        })
+    })
+  })
+
+
+})


### PR DESCRIPTION
### Description of Change
If TRUST_PROXY environment variable is set to true, enables the feature in the app so that the app can run behind proxies that terminate https and forward http

### Related Issue
fixes #33 
### Motivation and Context

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [ x ] Ran `npm run lint` and updated code style accordingly
- [ x ] `npm run test` passes
- [ x ] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ x ] tests are updated and/or added to cover new code

The documentation that this should be added to is probably in the sample website which I can't edit. 
- [ ] relevant documentation is changed and/or added

