### PR TITLE
Template homepage module options

### DIFF
--- a/config/strings.yaml
+++ b/config/strings.yaml
@@ -14,6 +14,12 @@ landing:
   tagline: One place for your organization's documents.
   viewAll: View All
   quickLink: <a href="/get-started">Get Started.</a>
+  modules:
+    # - tag: team
+    #   label: Find by team
+    #   style: button
+    - tag: featured
+      label: Useful Docs
 
 
 # partials/footer

--- a/config/strings.yaml
+++ b/config/strings.yaml
@@ -15,11 +15,12 @@ landing:
   viewAll: View All
   quickLink: <a href="/get-started">Get Started.</a>
   modules:
-    # - tag: team
-    #   label: Find by team
-    #   style: button
+    - tag: team
+      label: Find by team
+      style: button
     - tag: featured
       label: Useful Docs
+      style: docs
 
 
 # partials/footer

--- a/layouts/pages/index.ejs
+++ b/layouts/pages/index.ejs
@@ -18,41 +18,14 @@
         <%- include('../partials/search', {style: 'homepage', focus: 'autofocus', msgOnFocus: template('search.placeholder')}) %>
 
         <div class="featured-cat">
-          <div class="teams-cat-container">
-            <h3>Find by Team</h3>
-            <ul class="teams-cat-list">
-              <% teams.slice(0, 6).forEach((team) => { %>
-                <li data-team-id="<%= team.id %>"><a class="button btn-cat" href="<%= team.path %>"><%= team.prettyName %></a></li>
-              <% }) %>
-            </ul>
-          </div>
-          <div class="featured-cat-container">
-            <h3>Useful Docs</h3>
-            <ul class="featured-cat-list">
-              <% featured.forEach((doc) => { %>
-                <% const type = doc.resourceType %>
-                <li>
-                  <%
-                  const iconMap = {
-                    document: 'file-o',
-                    spreadsheet: 'table',
-                    'text/html': 'file-o',
-                    folder: 'folder',
-                    presentation: 'clone',
-                    image: 'picture-o',
-                    video: 'video-camera',
-                    pdf: 'file-pdf-o'
-                  }
-                  const iconName = iconMap[type] || 'external-link'
-                  const className = `fa-${iconName}`
-                  %>
-                  <i class="fa foldericon <%= className %>" aria-hidden="true"></i>
-                  <a href="<%= doc.path %>"><%= doc.prettyName %></a>
-                </li>
-              <% }) %>
-              <li><a class="button btn-homepage" href="/categories"><%- template('landing.viewAll') %></a></li>
-            </ul>
-          </div>
+          <% if (modules.length) { 
+            modules.forEach((module, i, all) => {
+          %>
+            <%- include('../partials/landingModule', module) %>
+          <%  })  
+          } else { %>
+          <!-- Eventually we might display a warning here about why this space is empty. -->
+          <% } %>
         </div>
 
       </div>

--- a/layouts/partials/landingModule.ejs
+++ b/layouts/partials/landingModule.ejs
@@ -3,7 +3,7 @@ const {tag, label, items, style} = locals
 const itemsLimited = items.slice(0, 6)
 %>
 
-<div class="<%= tag %>-cat-container">
+<div class="cat-container <%= tag %>-cat-container style-<%= style %>">
   <h3><%= label %></h3>
   <ul class="<%= tag %>-cat-list">
     <% itemsLimited.forEach((item) => { 

--- a/layouts/partials/landingModule.ejs
+++ b/layouts/partials/landingModule.ejs
@@ -1,0 +1,36 @@
+<%
+const {tag, label, items, style} = locals
+const itemsLimited = items.slice(0, 6)
+%>
+
+<div class="<%= tag %>-cat-container">
+  <h3><%= label %></h3>
+  <ul class="<%= tag %>-cat-list">
+    <% itemsLimited.forEach((item) => { 
+      if (style === 'button') { %>
+        <li data-<%= tag %>-id="<%= item.id %>"><a class="button btn-cat" href="<%= item.path %>"><%= item.prettyName %></a></li>
+      <% } else {
+        const type = item.resourceType 
+        const iconMap = {
+          document: 'file-o',
+          spreadsheet: 'table',
+          'text/html': 'file-o',
+          folder: 'folder',
+          presentation: 'clone',
+          image: 'picture-o',
+          video: 'video-camera',
+          pdf: 'file-pdf-o'
+        }
+        const iconName = iconMap[type] || 'external-link'
+        const className = `fa-${iconName}` %>
+        <li>
+          <i class="fa foldericon <%= className %>" aria-hidden="true"></i>
+          <a href="<%= item.path %>"><%= item.prettyName %></a>
+        </li>
+    <% }
+    }) 
+    if (tag === 'featured') { %>
+      <li><a class="button btn-homepage" href="/categories"><%- template('landing.viewAll') %></a></li>
+    <% } %>
+  </ul>
+</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3000,7 +3000,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3024,13 +3025,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3047,19 +3050,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3190,7 +3196,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3204,6 +3211,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3220,6 +3228,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3228,13 +3237,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3255,6 +3266,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3343,7 +3355,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3357,6 +3370,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3452,7 +3466,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3494,6 +3509,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3515,6 +3531,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3563,13 +3580,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/server/utils.js
+++ b/server/utils.js
@@ -75,7 +75,7 @@ function getConfig() {
 
   if (customExists) {
     const customConfig = yaml.load(fs.readFileSync(path.join(__dirname, '../custom/strings.yaml')), 'utf8') || {}
-    config = merge(config, customConfig)
+    config = merge(config, customConfig, {arrayMerge: (config, custom) => custom || config})
   }
 
   return config

--- a/server/utils.js
+++ b/server/utils.js
@@ -2,7 +2,7 @@
 const fs = require('fs')
 const path = require('path')
 const yaml = require('js-yaml')
-const {get: deepProp} = require('lodash')
+const { get: deepProp } = require('lodash')
 const merge = require('deepmerge')
 
 const log = require('./logger')
@@ -53,14 +53,14 @@ const middlewares = fs.existsSync(path.join(__dirname, '../custom/middleware')) 
 
 // create object with preload and postload middleware functions
 exports.allMiddleware = middlewares.reduce((m, item) => {
-  const {preload, postload} = require(path.join(__dirname, `../custom/middleware/${item}`))
+  const { preload, postload } = require(path.join(__dirname, `../custom/middleware/${item}`))
   return {
     preload: preload ? m.preload.concat(preload) : m.preload,
     postload: postload ? m.postload.concat(postload) : m.postload
   }
 }, {
-  preload: [], postload: []
-})
+    preload: [], postload: []
+  })
 
 const config = getConfig()
 function getConfig() {
@@ -79,6 +79,10 @@ function getConfig() {
   }
 
   return config
+}
+
+exports.getConfig = (configPath) => {
+  return deepProp(config, configPath)
 }
 
 exports.stringTemplate = (configPath, ...args) => {

--- a/server/utils.js
+++ b/server/utils.js
@@ -59,8 +59,8 @@ exports.allMiddleware = middlewares.reduce((m, item) => {
     postload: postload ? m.postload.concat(postload) : m.postload
   }
 }, {
-    preload: [], postload: []
-  })
+  preload: [], postload: []
+})
 
 const config = getConfig()
 function getConfig() {

--- a/styles/partials/core/_pages.scss
+++ b/styles/partials/core/_pages.scss
@@ -205,8 +205,7 @@
         display: flex;
     	}
 
-      .featured-cat-container,
-      .team-cat-container {
+      .cat-container {
         flex: 0 50%;
         // margin-top: -7px;
         margin-bottom: 40px;
@@ -232,47 +231,48 @@
           list-style-type: none;
         }
 
-      }
-
-      .team-cat-container {
-        ul {
-          // margin-top: -10px;
-          margin-bottom: 25px;
-
-          li {
-            display: inline-block;
-
-            @include tablet{
-          		display: block;
-          	}
-            @include desktop{
-          		display: block;
-          	}
-          }
-        }
-      }
-
-      .featured-cat-list {
-        padding-left: 7px;
-        a {
-          color: $btn-default-text-color;
-          -webkit-font-smoothing: antialiased;
-        }
-        li {
-          margin-bottom: 7px;
-          position: relative;
-
-          &:last-of-type {
-            &:before {
-              display: none;
+        &.style-button {
+          ul {
+            // margin-top: -10px;
+            margin-bottom: 25px;
+  
+            li {
+              display: inline-block;
+  
+              @include tablet{
+                display: block;
+              }
+              @include desktop{
+                display: block;
+              }
             }
           }
+        }
 
-          .fa {
-            color: $main-homepage-icon-color;
-            margin-right: 7px;
-            font-size: 14px;
-            line-height: 18px;
+        &.style-docs {
+          ul {
+            padding-left: 7px;
+            a {
+              color: $btn-default-text-color;
+              -webkit-font-smoothing: antialiased;
+            }
+            li {
+              margin-bottom: 7px;
+              position: relative;
+    
+              &:last-of-type {
+                &:before {
+                  display: none;
+                }
+              }
+    
+              .fa {
+                color: $main-homepage-icon-color;
+                margin-right: 7px;
+                font-size: 14px;
+                line-height: 18px;
+              }
+            }
           }
         }
       }

--- a/styles/partials/core/_pages.scss
+++ b/styles/partials/core/_pages.scss
@@ -206,7 +206,7 @@
     	}
 
       .featured-cat-container,
-      .teams-cat-container {
+      .team-cat-container {
         flex: 0 50%;
         // margin-top: -7px;
         margin-bottom: 40px;
@@ -234,7 +234,7 @@
 
       }
 
-      .teams-cat-container {
+      .team-cat-container {
         ul {
           // margin-top: -10px;
           margin-bottom: 25px;


### PR DESCRIPTION
### Description of Change
A little less ambitious than #2, takes the existing homepage modules and converts them from distinct render items with required tags and abstracts the configuration options into a list. Could eventually be helpful for completing #2, but a good stopgap measure for now to help folks that don't find "Find by Team" useful for their Library site.

### Related Issue

### Motivation and Context
It wasn't possible to customize the order, language, or tags of the homepage modules before. This makes customizing those much easier while preserving the existing functionality.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [n/a] relevant documentation is changed and/or added

