### PR TITLE
Disable linting on regex

### DIFF
--- a/server/docs.js
+++ b/server/docs.js
@@ -16,6 +16,7 @@ const supportedTypes = new Set(['document', 'spreadsheet', 'text/html'])
 exports.cleanName = (name = '') => {
   return name
     .trim()
+    // eslint-disable-next-line
     .replace(/^(\d+[-–—_\s]*)([^\d\/\-^\s]+)/, '$2') // remove leading numbers and delimiters
     .replace(/\s*\|\s*([^|]+)$/i, '')
     .replace(/\W+home$/i, '')

--- a/server/docs.js
+++ b/server/docs.js
@@ -16,7 +16,7 @@ const supportedTypes = new Set(['document', 'spreadsheet', 'text/html'])
 exports.cleanName = (name = '') => {
   return name
     .trim()
-    // eslint-disable-next-line
+    // eslint-disable-next-line no-useless-escape
     .replace(/^(\d+[-–—_\s]*)([^\d\/\-^\s]+)/, '$2') // remove leading numbers and delimiters
     .replace(/\s*\|\s*([^|]+)$/i, '')
     .replace(/\W+home$/i, '')


### PR DESCRIPTION
### Description of Change
<!-- Thanks for contributing! Please describe your addition and review the requirements below. Review the contributor's guide before submitting your pull request: https://github.com/nytimes/library/blob/master/CONTRIBUTING.md -->
This regex fails our lint process; modifying the regex based on the lint rule doesn't keep existing behavior so we should disable it for this line.

### Related Issue

### Motivation and Context

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [ ] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

