### PR TITLE
Tag use and formatting consistency for inline code blocks

### DIFF
--- a/server/formatter.js
+++ b/server/formatter.js
@@ -108,9 +108,9 @@ function formatCode(html) {
     return `<pre type="${codeType}">${formatCodeContent(content)}</pre>`
   })
 
-  // Replace single backticks with <tt>
+  // Replace single backticks with <code>
   html = html.replace(/`(.+?)`/g, (match, content) => {
-    return `<tt>${formatCodeContent(content)}</tt>`
+    return `<code>${formatCodeContent(content)}</code>`
   })
 
   html = html.replace(/&lt;%-(.+)%&gt;/g, (match, content) => {

--- a/styles/partials/core/_categories.scss
+++ b/styles/partials/core/_categories.scss
@@ -425,8 +425,10 @@
       padding: 1px 0px;
       margin: 0 4px;
       -webkit-box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
+      -moz-box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
       box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
       -webkit-box-decoration-break: clone;
+      -moz-box-decoration-break: clone;
       box-decoration-break: clone;
     }
   }

--- a/styles/partials/core/_categories.scss
+++ b/styles/partials/core/_categories.scss
@@ -419,10 +419,15 @@
       }
     }
 
-    tt {
+    code {
       background: $accent-lightest;
       color: $accent-dark;
-      padding: 2px 5px;
+      padding: 1px 0px;
+      margin: 0 4px;
+      -webkit-box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
+      box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
     }
   }
 


### PR DESCRIPTION
### Description of Change
This proposed change does two things:
* Switches from using `<tt>` blocks for inline code snippets to the [non-deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt) `<code>` block, which anecdotally is more commonly used for this purpose and also seems more descriptive.
* It also makes some minor adjustments to the padding / margin settings on these blocks, inspired by [squidfunk/mkdocs-material](https://github.com/squidfunk/mkdocs-material/blob/6e43b874f6eaa9764b67a0902d0eae38bbb35f35/src/assets/stylesheets/base/_typeset.scss#L184-L188), which makes code blocks that span multiple lines have consistent spacing with those that don't:

![image](https://user-images.githubusercontent.com/677570/63617725-2c560500-c5b8-11e9-92da-3d3e115d19ee.png)

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added

