### PR TITLE
slight tweak to autocomplete logic

### DIFF
--- a/layouts/partials/search.ejs
+++ b/layouts/partials/search.ejs
@@ -8,7 +8,7 @@
   </form>
 
   <% const style = locals.style || 'plaintext' %>
-  <div class="additional-menus <%= style %>"">
+  <div class="additional-menus <%= style %>">
     <a href="/categories"><button type="button" class="button btn-<%= style %>"><%- template('landing.viewAll') %></button></a>
     <%# <a href="#"><button type="button" class="btn-plaintext">Onboarding Guide</button></a>%>
   </div>

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -107,14 +107,24 @@ $(document).ready(function() {
     cb(filenames.filter((str) => substrRegex.test(str)))
   }
 
+  var $searchBox = $('#search-box')
   // setup typeahead
-  $('#search-box').typeahead({
+  $searchBox.typeahead({
     hilight: true
   }, {
     name: 'documents',
     source: filenameMatcher
   })
+
+  // when the typeahead selects a result, immediately submit the form
+  // and tell the backend it was an autocomplete so we can go there directly.
+  $searchBox.on('typeahead:select', function (event, selectedItem) {
+    var $form = $searchBox.closest('form')
+    $form.append('<input type="hidden" name="autocomplete" value="1"/>')
+    $form.submit()
+  })
 })
+
 
 function personalizeHomepage(userId) {
 

--- a/server/routes/pages.js
+++ b/server/routes/pages.js
@@ -34,8 +34,9 @@ async function handlePage(req, res) {
     return search.run(q, driveType).then((results) => {
       // special rule for the autocomplete case, go directly to the item if we find it.
       if (autocomplete) {
-        const targetItem = results.find((i) => i.prettyName === q)
-        if (targetItem) return res.redirect(targetItem.path)
+        // filter here first to make sure only _one_ document exists with this exact name
+        const exactMatches = results.filter((i) => i.prettyName === q)
+        if (exactMatches.length === 1) return res.redirect(exactMatches[0].path)
       }
 
       res.render(template, { q, results, template: stringTemplate })

--- a/server/routes/pages.js
+++ b/server/routes/pages.js
@@ -29,9 +29,15 @@ async function handlePage(req, res) {
   if (!pages.has(page)) return 'next'
 
   const template = `pages/${page}`
-  const { q, id, dest } = req.query
+  const { q, id, dest, autocomplete } = req.query
   if (page === 'search' && q) {
     return search.run(q, driveType).then((results) => {
+      // special rule for the autocomplete case, go directly to the item if we find it.
+      if (autocomplete) {
+        const targetItem = results.find((i) => i.prettyName === q)
+        if (targetItem) return res.redirect(targetItem.path)
+      }
+
       res.render(template, { q, results, template: stringTemplate })
     })
   }


### PR DESCRIPTION
### Description of Change
As followup to #51, this small tweak updates the searching logic so that exact document matches from autocomplete immediately take you to the page for the item, instead of requiring a manual submit and selecting the item on the search results page.

### Related Issue
#51, Autocomplete for search.

### Motivation and Context
Typical behavior when using autocomplete for an exact item name is to go directly there.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed


