### PR TITLE
Last Edited no longer appears in search when last editor is undefined

### DIFF
--- a/layouts/pages/search.ejs
+++ b/layouts/pages/search.ejs
@@ -17,7 +17,7 @@
               <% if (res.folder) { %>
                 <%- template('search.results.label.folder', res.folder.path, res.folder.prettyName || 'Home')%>&nbsp;
               <% } %>
-              <% if (res.lastModifyingUser) { %>
+              <% if (res.lastModifyingUser && res.lastModifyingUser.displayName) { %>
                 <%- template('search.results.label.person', res.lastModifyingUser.displayName) %>
               <% } %>
               <%= res.lastUpdated %>


### PR DESCRIPTION
### Description of Change
When Library cannot find a "last editor", it does not show a "Last Edited By" string

### Related Issue
Closes #68

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added

