### PR TITLE
small grammatical fix

### DIFF
--- a/custom/README.md
+++ b/custom/README.md
@@ -84,7 +84,7 @@ functions. These functions must be valid middleware with params
 By default, Library uses an in-memory cache. A custom cache client can be written
 to be used in its place.
 
-A custom cache client can used by placing a `store.js` file in the `custom/cache`
+A custom cache client can be used by placing a `store.js` file in the `custom/cache`
 directory. This file must export an object with the methods
 - `set(key, value, callback)`, where `callback` takes `(err, success)`
 - `get(key, callback)`, where `callback` takes `(err, value)`


### PR DESCRIPTION
Changed sentence from: A custom cache client can used by placing a store.js file in the custom/cache directory.
To: A custom cache client can be used by placing a store.js file in the custom/cache directory.

### Description of Change
<!-- Thanks for contributing! Please describe your addition and review the requirements below. Review the contributor's guide before submitting your pull request: https://github.com/nytimes/library/blob/master/CONTRIBUTING.md -->

### Related Issue

### Motivation and Context

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [ ] Ran `npm run lint` and updated code style accordingly
- [ ] `npm run test` passes
- [ ] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

