### PR TITLE
Remove comments after vars in .env in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,23 @@ If you have questions about how to get your copy of Library up and running, [joi
 4. Create a `.env` file at the project root. An example `.env` might look like
 
 ```bash
-NODE_ENV=development # node environment
+# node environment (development or production)
+NODE_ENV=development
 # Google oAuth credentials
 GOOGLE_CLIENT_ID=123456-abcdefg.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=abcxyz12345
 GCP_PROJECT_ID=library-demo-1234
-APPROVED_DOMAINS="nytimes.com,dailypennsylvanian.com" # comma separated list of approved access domains.
+# comma separated list of approved access domains.
+APPROVED_DOMAINS="nytimes.com,dailypennsylvanian.com"
 SESSION_SECRET=supersecretvalue
 
 # Google drive Configuration
-DRIVE_TYPE=team # or folder, if using a folder instead of a team drive
-DRIVE_ID=0123456ABCDEF # the ID of your team's drive or shared folder. The string of random numbers and letters at the end of your team drive or folder url.
+# team or folder ("folder" if using a folder instead of a team drive)
+DRIVE_TYPE=team
+# the ID of your team's drive or shared folder. The string of random numbers and letters at the end of your team drive or folder url.
+DRIVE_ID=0123456ABCDEF
 ```
-Make sure to remove all comments after the `DRIVE_TYPE` and `DRIVE_ID` vars.
+Make sure to not put any comments in the same line as `DRIVE_TYPE` and `DRIVE_ID` vars.
 
 Ensure you share your base drive or folder with the email address associated with the service account created in step 2.
 


### PR DESCRIPTION
To avoid errors when copy-pasting .env file, 
comments from the same line are removed.

### Description of Change
<!-- Thanks for contributing! Please describe your addition and review the requirements below. Review the contributor's guide before submitting your pull request: https://github.com/nytimes/library/blob/master/CONTRIBUTING.md -->

### Related Issue

### Motivation and Context

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [ ] Ran `npm run lint` and updated code style accordingly
- [ ] `npm run test` passes
- [ ] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

