### PR TITLE
fixes #99, no xmlMode

### DIFF
--- a/server/cache/store.js
+++ b/server/cache/store.js
@@ -3,7 +3,7 @@
 const cacheManager = require('cache-manager')
 const {promisify} = require('util')
 
-const cache = cacheManager.caching({ store: 'memory' })
+const cache = cacheManager.caching({store: 'memory'})
 
 // Export in-memory cache with promisified get and set methods
 module.exports = {

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -149,7 +149,7 @@ function checkForTableOfContents($, aTags) {
 
 function fetchByline(html, creatorOfDoc) {
   let byline = creatorOfDoc
-  const $ = cheerio.load(html, {xmlMode: true}) // prevent wrapping html tags, see cheerio/issues/1031
+  const $ = cheerio.load(html)
 
   // Iterates through all p tags to find byline
   $('p').each((index, p) => {
@@ -170,7 +170,7 @@ function fetchByline(html, creatorOfDoc) {
   })
 
   return {
-    html: $.html(),
+    html: $('head').html() + $('body').html(), // include head for list style block
     byline
   }
 }

--- a/server/utils.js
+++ b/server/utils.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const path = require('path')
 const {promisify} = require('util')
 const yaml = require('js-yaml')
-const { get: deepProp } = require('lodash')
+const {get: deepProp} = require('lodash')
 const merge = require('deepmerge')
 const mime = require('mime-types')
 
@@ -58,7 +58,7 @@ const middlewares = fs.existsSync(path.join(__dirname, '../custom/middleware')) 
 
 // create object with preload and postload middleware functions
 exports.allMiddleware = middlewares.reduce((m, item) => {
-  const { preload, postload } = require(path.join(__dirname, `../custom/middleware/${item}`))
+  const {preload, postload} = require(path.join(__dirname, `../custom/middleware/${item}`))
   return {
     preload: preload ? m.preload.concat(preload) : m.preload,
     postload: postload ? m.postload.concat(postload) : m.postload
@@ -121,7 +121,7 @@ exports.assetDataURI = async (filePath) => {
   const mimeType = mime.lookup(path.posix.basename(publicPath))
   const fullPath = path.join(__dirname, '..', publicPath)
 
-  const data = await readFileAsync(fullPath, { encoding: 'base64' })
+  const data = await readFileAsync(fullPath, {encoding: 'base64'})
   const src = `data:${mimeType};base64,${data}`
   return src
 }


### PR DESCRIPTION
Looks like #92 switch to `xmlMode` introduced some self closing `a` tags, which Chrome is failing to recognize. This PR disables `xmlMode` and addresses the intent of that switch by returning the `head` and `body` HTML instead of the entirety of the cheerio virtual `$.html()`.

### Related Issue
Closes #99 

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- ~[ ] tests are updated and/or added to cover new code~
- ~[ ] relevant documentation is changed and/or added~

