### PR TITLE
update APPROVED_DOMAINS documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ NODE_ENV=development
 GOOGLE_CLIENT_ID=123456-abcdefg.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=abcxyz12345
 GCP_PROJECT_ID=library-demo-1234
-# comma separated list of approved access domains.
-APPROVED_DOMAINS="nytimes.com,dailypennsylvanian.com"
+# comma separated list of approved access domains or email addresses (regex is supported).
+APPROVED_DOMAINS="nytimes.com,dailypennsylvanian.com,(.*)?ar.org,demo.user@demo.site.edu"
 SESSION_SECRET=supersecretvalue
 
 # Google drive Configuration


### PR DESCRIPTION
### Description of Change

In https://github.com/nytimes/library/pull/26 the site access options were extended to include specific email addresses and regex, but the README was not updated.

This commit updates the README to document the new extended behaviour of `APPROVED_DOMAINS`

### Related Issue

https://github.com/nytimes/library/issues/7

### Motivation and Context

It looks like functionality was extended without it being documented anywhere. I only found out that it existed after looking through the issues.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [ ] ~Ran `npm run lint` and updated code style accordingly~
- [ ] ~`npm run test` passes~
- [ ] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] ~tests are updated and/or added to cover new code~
- [ ] relevant documentation is changed and/or added

