### PR TITLE
remove unused dep assert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -921,29 +921,6 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
-    "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "requires": {
-        "util": "0.10.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
-        "util": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "requires": {
-            "inherits": "2.0.1"
-          }
-        }
-      }
-    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "server/index.js",
   "dependencies": {
     "@google-cloud/datastore": "^5.1.0",
-    "assert": "^1.4.1",
     "cache-manager": "^3.2.1",
     "chai": "^4.2.0",
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
The `assert` npm is unused; we import assertion functionality from mocha instead.

This PR replaces #126.

