### PR TITLE
Fix inconsistent line starts for code blocks

### DIFF
--- a/styles/partials/core/_categories.scss
+++ b/styles/partials/core/_categories.scss
@@ -394,7 +394,7 @@
       }
 
       .line-number::before {
-        content: counter(line-numbering);
+        content: counter(line-numbering, decimal-leading-zero);
         counter-increment: line-numbering;
         padding-right: 1em;
         /* space after numbers */


### PR DESCRIPTION
### Description of Change

Adds `decimal-leading-zero` to the CSS counter, so that line numbers are always the same number of digits.

### Related Issue

### Motivation and Context

👋 Working on a code-block-heavy doc, and realized that the starting position of lines varied based on how many digits the line number had:

![image](https://user-images.githubusercontent.com/5354254/85062274-357f1680-b176-11ea-8f3a-9cfa5e5b89de.png)

Now, with the fix:

![image](https://user-images.githubusercontent.com/5354254/85062308-49c31380-b176-11ea-8dc8-d6ac0e93c187.png)

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added

