### PR TITLE
Fix line number width bug and add syntax highlighting

### DIFF
--- a/layouts/partials/head.ejs
+++ b/layouts/partials/head.ejs
@@ -8,6 +8,42 @@
   <![endif]-->
 
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+
+  <link rel="stylesheet"
+      href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/styles/default.min.css">
+  <script defer src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/highlight.min.js"></script>
+  <!-- supported languages -->
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/json.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/csharp.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/diff.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/less.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/nginx.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/perl.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/ruby.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/shell.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/yaml.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/apache.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/cpp.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/go.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/java.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/lua.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/objectivec.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/plaintext.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/rust.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/swift.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/bash.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/xml.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/javascript.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/makefile.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/php.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/python.min.js"></script>
+  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/scss.min.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      hljs.initHighlightingOnLoad();
+    });
+  </script>
+
   <% if (locals.inlineCSS) { %>
     <style type="text/css"><%- inlineCSS %></style>
   <% } else { %>

--- a/layouts/partials/head.ejs
+++ b/layouts/partials/head.ejs
@@ -11,38 +11,6 @@
 
   <link rel="stylesheet"
       href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/styles/default.min.css">
-  <script defer src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/highlight.min.js"></script>
-  <!-- supported languages -->
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/json.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/csharp.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/diff.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/less.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/nginx.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/perl.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/ruby.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/shell.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/yaml.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/apache.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/cpp.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/go.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/java.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/lua.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/objectivec.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/plaintext.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/rust.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/swift.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/bash.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/xml.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/javascript.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/makefile.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/php.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/python.min.js"></script>
-  <script defer charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/scss.min.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      hljs.initHighlightingOnLoad();
-    });
-  </script>
 
   <% if (locals.inlineCSS) { %>
     <style type="text/css"><%- inlineCSS %></style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4144,6 +4144,11 @@
         "dasherize": "2.0.0"
       }
     },
+    "highlight.js": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.1.tgz",
+      "integrity": "sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg=="
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "google-auth-library": "^3.1.1",
     "googleapis": "^48.0.0",
     "helmet-csp": "^2.10.0",
+    "highlight.js": "^10.1.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "md5": "^2.2.1",

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
   var $document = $(document)
   var $html = $('html')
 
-  $("pre").html(function (index, html) {
+  $("pre code").html(function (index, html) {
     return html.split(/\r?\n/).map(function(line) {
       return [
         '<div class="line">',

--- a/server/csp.json
+++ b/server/csp.json
@@ -1,7 +1,7 @@
 {
   "defaultSrc": ["'self'"],
   "scriptSrc": ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com", "*.google-analytics.com"],
-  "styleSrc": ["'self'", "'unsafe-inline'", "fonts.googleapis.com", "maxcdn.bootstrapcdn.com", "*.googleusercontent.com"],
+  "styleSrc": ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com", "fonts.googleapis.com", "maxcdn.bootstrapcdn.com", "*.googleusercontent.com"],
   "fontSrc": ["'self'", "fonts.gstatic.com", "maxcdn.bootstrapcdn.com"],
   "imgSrc": ["'self'", "data:", "*.googleusercontent.com", "*.google-analytics.com"],
   "frameSrc": ["'self'","data:","*.youtube.com"],

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -2,6 +2,7 @@ const pretty = require('pretty')
 const cheerio = require('cheerio')
 const qs = require('querystring')
 const unescape = require('unescape')
+const hljs = require('highlight.js')
 const list = require('./list')
 
 /* Your one stop shop for all your document processing needs. */
@@ -107,7 +108,9 @@ function formatCode(html) {
     // strip interior <p> tags added by google
     content = content.replace(/<\/p><p>/g, '\n').replace(/<\/?p>/g, '')
 
-    return `<pre><code class=${codeType}>${formatCodeContent(content)}</code></pre>`
+    const formattedContent = formatCodeContent(content)
+    const highlighted = hljs.highlight(codeType, unescape(formattedContent), true).value
+    return `<pre><code class=${codeType}>${highlighted}</code></pre>`
   })
 
   // Replace single backticks with <code>

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -109,8 +109,12 @@ function formatCode(html) {
     content = content.replace(/<\/p><p>/g, '\n').replace(/<\/?p>/g, '')
 
     const formattedContent = formatCodeContent(content)
-    const highlighted = lang ? hljs.highlight(lang, unescape(formattedContent), true) : hljs.highlightAuto(unescape(formattedContent))
-    return `<pre><code data-lang="${highlighted.language}">${highlighted.value}</code></pre>`
+    if (lang) {
+      const textOnlyContent = cheerio.load(formattedContent).text()
+      const highlighted = hljs.highlight(lang, textOnlyContent, true)
+      return `<pre><code data-lang="${highlighted.language}">${highlighted.value}</code></pre>`
+    }
+    return `<pre><code>${formattedContent}</code></pre>`
   })
 
   // Replace single backticks with <code>

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -107,7 +107,7 @@ function formatCode(html) {
     // strip interior <p> tags added by google
     content = content.replace(/<\/p><p>/g, '\n').replace(/<\/?p>/g, '')
 
-    return `<pre type="${codeType}">${formatCodeContent(content)}</pre>`
+    return `<pre><code class=${codeType}>${formatCodeContent(content)}</code></pre>`
   })
 
   // Replace single backticks with <code>

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -109,8 +109,8 @@ function formatCode(html) {
     content = content.replace(/<\/p><p>/g, '\n').replace(/<\/?p>/g, '')
 
     const formattedContent = formatCodeContent(content)
-    const highlighted = hljs.highlight(codeType, unescape(formattedContent), true).value
-    return `<pre><code class=${codeType}>${highlighted}</code></pre>`
+    const highlighted = codeType ? hljs.highlight(codeType, unescape(formattedContent), true) : hljs.highlightAuto(unescape(formattedContent))
+    return `<pre><code class=${codeType}>${highlighted.value}</code></pre>`
   })
 
   // Replace single backticks with <code>

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -104,13 +104,13 @@ function normalizeHtml(html) {
 
 function formatCode(html) {
   // Expand code blocks
-  html = html.replace(/<p>```(.*?)<\/p>(.+?)<p>```<\/p>/ig, (match, codeType, content) => {
+  html = html.replace(/<p>```(.*?)<\/p>(.+?)<p>```<\/p>/ig, (match, lang, content) => {
     // strip interior <p> tags added by google
     content = content.replace(/<\/p><p>/g, '\n').replace(/<\/?p>/g, '')
 
     const formattedContent = formatCodeContent(content)
-    const highlighted = codeType ? hljs.highlight(codeType, unescape(formattedContent), true) : hljs.highlightAuto(unescape(formattedContent))
-    return `<pre><code class=${codeType}>${highlighted.value}</code></pre>`
+    const highlighted = lang ? hljs.highlight(lang, unescape(formattedContent), true) : hljs.highlightAuto(unescape(formattedContent))
+    return `<pre><code data-lang="${highlighted.language}">${highlighted.value}</code></pre>`
   })
 
   // Replace single backticks with <code>

--- a/styles/partials/core/_categories.scss
+++ b/styles/partials/core/_categories.scss
@@ -377,6 +377,19 @@
       margin-left: 80px;
     }
 
+    code {
+      background: $accent-lightest;
+      color: $accent-dark;
+      padding: 1px 0px;
+      margin: 0 4px;
+      -webkit-box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
+      -moz-box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
+      box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
+      -webkit-box-decoration-break: clone;
+      -moz-box-decoration-break: clone;
+      box-decoration-break: clone;
+    }
+
     pre{
       counter-reset:line-numbering;
       background: $accent-lightest;
@@ -419,19 +432,11 @@
         margin-top: 20px;
         line-height: 20px;
       }
-    }
 
-    code {
-      background: $accent-lightest;
-      color: $accent-dark;
-      padding: 1px 0px;
-      margin: 0 4px;
-      -webkit-box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
-      -moz-box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
-      box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
-      -webkit-box-decoration-break: clone;
-      -moz-box-decoration-break: clone;
-      box-decoration-break: clone;
+      code {
+        margin: 0;
+        padding: 0;
+      }
     }
   }
 

--- a/styles/partials/core/_categories.scss
+++ b/styles/partials/core/_categories.scss
@@ -395,10 +395,12 @@
 
       .line-number::before {
         content: counter(line-numbering);
+        display: block;
         counter-increment: line-numbering;
+        /* space after line numbers */
         padding-right: 1em;
-        /* space after numbers */
-        padding-left:8px;
+        /* space before numbers */
+        padding-left:4px;
         width: 1.5em;
         text-align: right;
         opacity: 0.5;

--- a/test/unit/htmlProcessing.test.js
+++ b/test/unit/htmlProcessing.test.js
@@ -95,8 +95,8 @@ describe('HTML processing', () => {
 
     it('scrubs smart quotes', function () {
       const codeBlock = this.output('pre')
-      assert.match(codeBlock.html(), /singleQuotedStr = &apos;str&apos;/)
-      assert.match(codeBlock.html(), /doubleQuotedStr = &quot;str&quot;/)
+      assert.match(codeBlock.html(), /singleQuotedStr = .*&apos;str&apos;/)
+      assert.match(codeBlock.html(), /doubleQuotedStr = .*&quot;str&quot;/)
     })
   })
 
@@ -104,7 +104,7 @@ describe('HTML processing', () => {
     describe('with inline code disabled', () => {
       it('does not modify code block content', function () {
         const codeBlock = this.output("pre:contains('codeblocks will not')")
-        assert.match(codeBlock.html(), /&lt;%-.*%&gt;/)
+        assert.match(codeBlock.html(), /&lt;.*%-.*%&gt;/)
       })
 
       it('does not unescape delimited code', function () {
@@ -130,7 +130,7 @@ describe('HTML processing', () => {
 
       it('does not modify code block content', function () {
         const codeBlock = this.codeEnabledOut("pre:contains('codeblocks will not')")
-        assert.match(codeBlock.html(), /&lt;%-.*%&gt;/)
+        assert.match(codeBlock.html(), /&lt;.*%-.*%&gt;/)
       })
 
       it('properly unescapes delimited code', function () {


### PR DESCRIPTION
### Description of Change

Fixes the line number width bug identified in #159, and adds support for hightlight.js for syntax highlighting. ~The highlight.js bundle and default languages adds about 40kB total gzipped, but they're all marked deferred, and so shouldn't interfere with page load time.~

This runs highlight.js on the backend, so the only new asset that needs to be loaded on the frontend is the highlight.js CSS, which is a few hundred bytes.

### Related Issue

### Motivation and Context

See #159 for line numbering context. Here's how this looks with fixed line numbers and syntax highlighting:

<img width="615" alt="Screen Shot 2020-06-23 at 12 23 17 PM" src="https://user-images.githubusercontent.com/5354254/85429186-5ebfee00-b54c-11ea-917a-1bb8b0a2b519.png">


### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

