### PR TITLE
Resurrect section html theming, custom layouts w/ fallback

### DIFF
--- a/custom/README.md
+++ b/custom/README.md
@@ -12,6 +12,10 @@ custom/
 ├── package.json       // for any npm modules required for custom code
 ├── cache
 │   └── store.js
+├── layouts
+│   └── categories
+│       ├── default.ejs // override for default content layout
+|       └── your-subsectioin.ejs // override for paths beginning with "your-subsection", for example
 ├── middleware
 │   ├── middleware1.js // pre/postload exports will be included as middleware
 │   └── middleware2.js
@@ -88,6 +92,17 @@ A custom cache client can be used by placing a `store.js` file in the `custom/ca
 directory. This file must export an object with the methods
 - `set(key, value, callback)`, where `callback` takes `(err, success)`
 - `get(key, callback)`, where `callback` takes `(err, value)`
+
+## Layouts
+Default layouts and templates are included in the top level `layouts` directory, and [are automatically superceded](https://github.com/nytimes/library/pull/200) by the presence of a mirror file within the custom/layouts folder.
+
+Using this folder, it's possible to both replace default templates that are invoked by your copy of Library to customize markup around your site, as well as to include dedicated template entrypoints for specific subsections of your site.
+
+For example, to override the markup on your search page, you could include a `custom/layouts/pages/search.ejs` file to replace the output of [this default template](https://github.com/nytimes/library/blob/master/layouts/pages/search.ejs#L23:L23).
+
+If you had a folder in your your Shared Drive/Folder that was called "Outer Space", creating a template at `custom/layouts/categories/outer-space.ejs` would serve as the entrypoint for all pages nested under that section of your site, replacing the [this default template](https://github.com/nytimes/library/blob/master/layouts/categories/default.ejs) for matching paths.
+
+When overriding default templates included with Library, it's usually a good idea to being by copying the base template to the custom location, then tweak until you achieve the desired effect. This helps ensure that important parts of the site furniture are not accidentally removed.
 
 ## Authentication
 By default, Library uses Google oAuth and [`passport`](http://www.passportjs.org/) to authenticate users. Different authentication systems can be used by overriding `custom/userAuth.js`, and can easily be implemented using

--- a/custom/README.md
+++ b/custom/README.md
@@ -15,7 +15,7 @@ custom/
 ├── layouts
 │   └── categories
 │       ├── default.ejs // override for default content layout
-|       └── your-subsectioin.ejs // override for paths beginning with "your-subsection", for example
+|       └── outer-space.ejs // override for paths beginning with "outer-space", for example 🚀
 ├── middleware
 │   ├── middleware1.js // pre/postload exports will be included as middleware
 │   └── middleware2.js

--- a/layouts/categories/default.ejs
+++ b/layouts/categories/default.ejs
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <html>
-  <%- include ../partials/head %>
+  <%- include('partials/head') %>
   <body>
     <h1 class="visually-hidden">Default template</h1>
-    <%- include ../partials/header %>
-    <%- include ../partials/nav %>
+    <%- include('partials/header') %>
+    <%- include('partials/nav') %>
     <div class="g-body">
       <div class="g-left-panel">
         <% if (locals.sections && locals.sections.length) { %>
           <!-- is this TOC -->
-          <%- include ../partials/sectionList %>
+          <%- include('partials/sectionList') %>
         <% } %>
         <!-- Hide sibling docs on normal pages -->
         <!-- <% if (locals.siblings && siblings.length) { %>
-        <%- include('../partials/siblingList', {kicker: template('folder.siblingList.heading')}) %>
+        <%- include('partials/siblingList', {kicker: template('folder.siblingList.heading')}) %>
         <% } %> -->
       </div>
 
@@ -23,11 +23,11 @@
         <% } %>
 
         <% if (locals.children && children.length) { %>
-        <%- include('../partials/childrenList', {children, kicker: template('folder.childrenList.kicker', title)}) %>
+        <%- include('partials/childrenList', {children, kicker: template('folder.childrenList.kicker', title)}) %>
         <% } %>
       </div>
 
-      <%- include('../partials/footer', { pageType: 'document', topLevelFolder: url.split('/')[1] }) %>
+      <%- include('partials/footer', { pageType: 'document', topLevelFolder: url.split('/')[1] }) %>
     </div>
   </body>
 </html>

--- a/layouts/errors/403.ejs
+++ b/layouts/errors/403.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
-  <%- include('../partials/head', {title: template('error.403.title')}) %>
+  <%- include('partials/head', {title: template('error.403.title')}) %>
   <body>
-    <%- include('../partials/header', {title: template('error.403.title'), parentLinks: []}) %>
+    <%- include('partials/header', {title: template('error.403.title'), parentLinks: []}) %>
     <div id="main-search-page">
       <div class="main-item">
         <div class="tagline">
@@ -11,7 +11,7 @@
         </div>
       </div>
 
-      <%- include('../partials/footer', {style: 'homepage'}) %>
+      <%- include('partials/footer', {style: 'homepage'}) %>
     </div>
 
   </body>

--- a/layouts/errors/404.ejs
+++ b/layouts/errors/404.ejs
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <%- include('../partials/head', {title: template('error.404.title')}) %>
+  <%- include('partials/head', {title: template('error.404.title')}) %>
   <body>
-    <%- include('../partials/header', {title: template('error.404.title'), parentLinks: []}) %>
+    <%- include('partials/header', {title: template('error.404.title'), parentLinks: []}) %>
     <div id="main-search-page">
       <div class="main-item">
         <div class="tagline">
           <h1><%- template('error.404.heading') %></h1>
           <p><%- template('error.404.message') %></p>
         </div>
-        <%- include('../partials/search', {style: 'homepage'}) %>
+        <%- include('partials/search', {style: 'homepage'}) %>
       </div>
 
-      <%- include('../partials/footer', {style: 'homepage'}) %>
+      <%- include('partials/footer', {style: 'homepage'}) %>
     </div>
 
   </body>

--- a/layouts/errors/500.ejs
+++ b/layouts/errors/500.ejs
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <%- include('../partials/head', {title: template('error.500.title')}) %>
+  <%- include('partials/head', {title: template('error.500.title')}) %>
   <body>
-    <%- include('../partials/header', {title: template('error.500.title'), parentLinks: []}) %>
+    <%- include('partials/header', {title: template('error.500.title'), parentLinks: []}) %>
     <div id="main-search-page">
       <div class="main-item">
         <div class="tagline">
           <h1><%- template('error.500.heading') %></h1>
           <p><%- template('error.500.message') %></p>
         </div>
-        <%- include('../partials/search', {style: 'homepage'}) %>
+        <%- include('partials/search', {style: 'homepage'}) %>
       </div>
 
-      <%- include('../partials/footer', {style: 'homepage'}) %>
+      <%- include('partials/footer', {style: 'homepage'}) %>
     </div>
 
   </body>

--- a/layouts/pages/categories.ejs
+++ b/layouts/pages/categories.ejs
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html>
-  <%- include('../partials/head', {title: template('landing.viewAll')}) %>
+  <%- include('partials/head', {title: template('landing.viewAll')}) %>
   <body>
-    <%- include('../partials/header', {parentLinks: [], title: template('landing.viewAll')}) %>
+    <%- include('partials/header', {parentLinks: [], title: template('landing.viewAll')}) %>
 
     <div class="g-upper-body">
-    <%- include('../partials/nav') %>
+    <%- include('partials/nav') %>
     </div>
 
     <div id="category-page" class="g-body">
       <div class="g-main-content">
       <% all.forEach((category) => { %>
-        <%- include('../partials/childrenList', {kicker: category.prettyName, children: category.children, link: category.path}) %>
+        <%- include('partials/childrenList', {kicker: category.prettyName, children: category.children, link: category.path}) %>
       <% }) %>
       </div>
       <script> seeMoreButton() </script>
-      <%- include('../partials/footer', { pageType: 'category_index' }) %>
+      <%- include('partials/footer', { pageType: 'category_index' }) %>
     </div>
   </body>
 </html>

--- a/layouts/pages/index.ejs
+++ b/layouts/pages/index.ejs
@@ -1,27 +1,27 @@
 <!DOCTYPE html>
 <html>
-  <%- include('../partials/head', {title: template('branding.prettyName')}) %>
+  <%- include('partials/head', {title: template('branding.prettyName')}) %>
   <body>
 
     <header id="masthead" class="masthead" role="banner">
       <div class="container">
-        <%- include ../partials/userTools %>
+        <%- include partials/userTools %>
       </div>
     </header>
 
     <div id="main-search-page">
       <div class="main-item">
-        <%- include('../partials/branding', {context: 'home'}) %>
+        <%- include('partials/branding', {context: 'home'}) %>
         <div class="tagline">
           <p><%- template('landing.tagline') %> <%- template('landing.quickLink') %></p>
         </div>
-        <%- include('../partials/search', {style: 'homepage', focus: 'autofocus', msgOnFocus: template('search.placeholder')}) %>
+        <%- include('partials/search', {style: 'homepage', focus: 'autofocus', msgOnFocus: template('search.placeholder')}) %>
 
         <div class="featured-cat">
           <% if (modules.length) { 
             modules.forEach((module, i, all) => {
           %>
-            <%- include('../partials/landingModule', module) %>
+            <%- include('partials/landingModule', module) %>
           <%  })  
           } else { %>
           <!-- Eventually we might display a warning here about why this space is empty. -->
@@ -29,7 +29,7 @@
         </div>
 
       </div>
-      <%- include('../partials/footer', {style: 'homepage', pageType: 'homepage'}) %>
+      <%- include('partials/footer', {style: 'homepage', pageType: 'homepage'}) %>
     </div>
   </body>
 </html>

--- a/layouts/pages/search.ejs
+++ b/layouts/pages/search.ejs
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
-  <%- include('../partials/head', {title: template('search.results.title', locals.q)}) %>
+  <%- include('partials/head', {title: template('search.results.title', locals.q)}) %>
   <body>
-    <%- include('../partials/header', {parentLinks: [], title: template('search.results.title', locals.q)}) %>
+    <%- include('partials/header', {parentLinks: [], title: template('search.results.title', locals.q)}) %>
 
-    <%- include('../partials/nav') %>
+    <%- include('partials/nav') %>
 
     <div class="g-body">
       <div class="g-main-content" id="g-search-page">
@@ -30,7 +30,7 @@
         <% } %>
       </div>
 
-      <%- include('../partials/footer', { pageType: 'search' }) %>
+      <%- include('partials/footer', { pageType: 'search' }) %>
     </div>
   </body>
 </html>

--- a/layouts/partials/nav.ejs
+++ b/layouts/partials/nav.ejs
@@ -2,7 +2,7 @@
   <%- include search %>
   <% if (locals.title) { %>
   <% if (locals.duplicates) { %>
-    <%- include('../partials/warning', {message: template('warning.duplicate', locals.duplicates, locals.parentId) }) %>
+    <%- include('partials/warning', {message: template('warning.duplicate', locals.duplicates, locals.parentId) }) %>
   <% } %>
   <h1 class="headline"><%= title %></h1>
   <div class="kicker">

--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ if ((process.env.TRUST_PROXY || '').toUpperCase() === 'TRUE') {
 }
 
 app.set('view engine', 'ejs')
-app.set('views', path.join(__dirname, '../layouts'))
+app.set('views', [path.join(__dirname, '../custom/layouts'), path.join(__dirname, '../layouts')]);
 
 app.get('/healthcheck', (req, res) => {
   res.send('OK')

--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ if ((process.env.TRUST_PROXY || '').toUpperCase() === 'TRUE') {
 }
 
 app.set('view engine', 'ejs')
-app.set('views', [path.join(__dirname, '../custom/layouts'), path.join(__dirname, '../layouts')]);
+app.set('views', [path.join(__dirname, '../custom/layouts'), path.join(__dirname, '../layouts')])
 
 app.get('/healthcheck', (req, res) => {
   res.send('OK')

--- a/server/utils.js
+++ b/server/utils.js
@@ -13,15 +13,15 @@ const layoutsDir = path.join(__dirname, '../layouts')
 const customLayoutsDir = path.join(__dirname, '../custom/layouts')
 exports.getTemplates = (subfolder) => {
   const defaultLayouts = fs.readdirSync(path.join(layoutsDir, subfolder)) || []
-  let customLayouts = [];
+  let customLayouts = []
   try {
     // NB: This will fail if custom/layouts does not exist.
     customLayouts = fs.readdirSync(path.join(customLayoutsDir, subfolder)) || []
   } catch (err) {
-    const level = err.code === 'ENOENT' ? 'debug' : 'warn';
-    log[level]('Custom layouts directory not found. Did you mean to include one?');
+    const level = err.code === 'ENOENT' ? 'debug' : 'warn'
+    log[level]('Custom layouts directory not found. Did you mean to include one?')
   }
-  
+
   return defaultLayouts.concat(customLayouts)
     .reduce((memo, filename) => {
       const [name] = filename.split('.')

--- a/server/utils.js
+++ b/server/utils.js
@@ -10,8 +10,19 @@ const mime = require('mime-types')
 const log = require('./logger')
 
 const layoutsDir = path.join(__dirname, '../layouts')
+const customLayoutsDir = path.join(__dirname, '../custom/layouts')
 exports.getTemplates = (subfolder) => {
-  return (fs.readdirSync(path.join(layoutsDir, subfolder)) || [])
+  const defaultLayouts = fs.readdirSync(path.join(layoutsDir, subfolder)) || []
+  let customLayouts = [];
+  try {
+    // NB: This will fail if custom/layouts does not exist.
+    customLayouts = fs.readdirSync(path.join(customLayoutsDir, subfolder)) || []
+  } catch (err) {
+    const level = err.code === 'ENOENT' ? 'debug' : 'warn';
+    log[level]('Custom layouts directory not found. Did you mean to include one?');
+  }
+  
+  return defaultLayouts.concat(customLayouts)
     .reduce((memo, filename) => {
       const [name] = filename.split('.')
       memo.add(name)


### PR DESCRIPTION
### Description of Change
This PR makes two changes to the way our templates work to support custom layouts.
1. It extends ejs view resolution logic to search `custom/layouts` first, before the default `layouts` folder
2. It updates the `getTemplates()` utility function to attempt to search this `custom/layouts` directory as well.

It also changes all the partial includes to not use relative paths, which means custom _partials_ can also be resolved from a custom/layouts folder.

This change makes preexisting logic that allowed custom category templates based on the root path of Library urls more useful, because now you could add a `custom/layouts/categories` folder with `your-base-url-segment.ejs` and override the root template for subcategories of your Library site.  


### Related Issue
#45 #36 

### Motivation and Context
There are a few exciting possibilities that custom HTML opens up for Library sites. This change represents a first pass at reenabling some customization functionality that was envisioned since the beginning, and empowering custom folder overrides to also change the HTML of any portion of the Library page, which was a missing feature at the time we originally open sourced the project.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- ~[ ] tests are updated and/or added to cover new code~
- [x] relevant documentation is changed and/or added

