### PR TITLE
Fix issue with custom import failure messaging

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -44,7 +44,7 @@ exports.requireWithFallback = (attemptPath) => {
     return require(customPath)
   } catch (err) {
     // if the file exists but we failed to pull it in, log that error at a warning level
-    if (fs.existsSync(customPath)) {
+    if (err.code !== 'MODULE_NOT_FOUND') {
       log.warn(`Failed pulling in custom file "${attemptPath}" @ ${customPath}. Error was:`, err)
     } else {
       log.debug(`No custom file "${attemptPath}" found in ${customPath}. Did you mean to include one?`)


### PR DESCRIPTION
### Description of Change
In #201, it was pointed out that the error message validation in `requireWithFallback` doesn't work well if the file extension was not passed in. `require()` knows to add it automatically, but our prior call to `fs.existsSync()` does not.

To fix the error message, we can rely on the error code to indicate if the module exists or not, rather than fs.existsSync(). 

### Related Issue
Possible fix for #201
 
### Motivation and Context
At some point this error message logic was broken, and it can get confusing for anyone customizing their Library site.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- ~[ ] tests are updated and/or added to cover new code~
- ~[ ] relevant documentation is changed and/or added~

