### PR TITLE
Use simple loop for list pagination instead of recursion

### DIFF
--- a/server/list.js
+++ b/server/list.js
@@ -124,7 +124,6 @@ async function fetchAllFiles({parentIds = [driveId], driveType = 'team', drive} 
 
     options.pageToken = data.nextPageToken
     levelItems.push(...data.files)
-
   } while (options.pageToken)
 
   // If this is not a shared folder, return completed list

--- a/server/list.js
+++ b/server/list.js
@@ -109,35 +109,25 @@ function getOptions(id) {
   }
 }
 
-async function fetchAllFiles({nextPageToken: pageToken, parentIds = [driveId], driveType = 'team', drive} = {}) {
+async function fetchAllFiles({parentIds = [driveId], driveType = 'team', drive} = {}) {
   const options = getOptions(parentIds)
+  const levelItems = []
 
-  if (pageToken) {
-    options.pageToken = pageToken
-  }
+  do {
+    // Gets files in single folder (shared) or files listed in single page of response (team)
+    const {data} = await Promise.race([
+      drive.files.list(options),
+      new Promise((resolve, reject) => setTimeout(() => reject(Error('drive.files.list timeout expired!')), driveTimeout * 1000))
+    ])
 
-  // Gets files in single folder (shared) or files listed in single page of response (team)
-  const {data} = await Promise.race([
-    drive.files.list(options),
-    new Promise((resolve, reject) => setTimeout(() => reject(Error('drive.files.list timeout expired!')), driveTimeout * 1000))
-  ])
+    log.debug(`got files and folders: ${data.files.length}, ${data.nextPageToken ? '' : 'no '}more results to fetch`)
 
-  const {files, nextPageToken} = data
-  const levelItems = files
+    options.pageToken = data.nextPageToken
+    levelItems.push(...data.files)
 
-  // If there is more data the API has not returned for the query, the request needs to continue
-  if (nextPageToken) {
-    const nextPageFiles = await fetchAllFiles({
-      nextPageToken,
-      drive,
-      parentIds,
-      driveType
-    })
-    log.debug(`next page files and folders: ${nextPageFiles.length}`)
-    return levelItems.concat(nextPageFiles)
-  }
+  } while (options.pageToken)
 
-  // If there are no more pages and this is not a shared folder, return completed list
+  // If this is not a shared folder, return completed list
   if (driveType !== 'folder') return levelItems
 
   // Continue searching if shared folder, since API only returns contents of the immediate parent folder


### PR DESCRIPTION
### Description of Change

I'm not sure why `fetchAllFiles()` was using recursion to handle paginating over the `drive.files.list()` API, but it was causing our library deployment (with >1k files) to miss files (only 40% of files were being found & indexed).  I converted the recursive pagination to a simple loop, which fixed the issue - now all files are being found and indexed.

### Motivation and Context

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] tests are updated and/or added to cover new code
- [ ] ~relevant documentation is changed and/or added~
  - internal change, no docs required

