### PR TITLE
Code block bugfixes

### DIFF
--- a/server/formatter.js
+++ b/server/formatter.js
@@ -104,9 +104,12 @@ function normalizeHtml(html) {
 
 function formatCode(html) {
   // Expand code blocks
-  html = html.replace(/<p>```(.*?)<\/p>(.+?)<p>```<\/p>/ig, (match, lang, content) => {
+  html = html.replace(/```(.*?)```/ig, (match, content) => {
     // strip interior <p> tags added by google
-    content = content.replace(/<\/p><p>/g, '\n').replace(/<\/?p>/g, '')
+    content = content.replace(/(?:<\/p><p>|<br\/?>)/g, '\n').replace(/<\/?p>/g, '').trim()
+    // try to find language hint within text block
+    const [, lang] = content.match(/^([^\n]+)\n(.+)/) || []
+    if (lang) content = content.replace(`${lang}\n`, '')
 
     const formattedContent = formatCodeContent(content)
     if (lang && hljs.getLanguage(lang)) {
@@ -117,7 +120,7 @@ function formatCode(html) {
     return `<pre><code>${formattedContent}</code></pre>`
   })
 
-  // Replace single backticks with <code>
+  // Replace single backticks with <code>, as long as they are not inside triple backticks
   html = html.replace(/`(.+?)`/g, (match, content) => {
     return `<code>${formatCodeContent(content)}</code>`
   })
@@ -144,6 +147,7 @@ function formatCode(html) {
 
 function formatCodeContent(content) {
   content = content.replace(/[‘’]|&#x201[89];/g, "'").replace(/[“”]|&#x201[CD];/g, '"') // remove smart quotes
+  content = content.replace(/`/g, '&#96;') // remove internal cases of backticks
   return content
 }
 

--- a/styles/partials/core/_categories.scss
+++ b/styles/partials/core/_categories.scss
@@ -393,8 +393,9 @@
     pre{
       counter-reset:line-numbering;
       background: $accent-lightest;
-      padding:0px 0px 20px 0;
-      width:600px;
+      padding: 0px 0px 20px 0;
+      width: 600px;
+      text-indent: 0;
 
       .line {
         display: flex;


### PR DESCRIPTION
### Description of Change
Since building the code block feature into Library initially, it appears the Google Drive HTML export has changed slightly. Where the HTML used to primarily include `p` tags for new lines (and could be reliably expected) the Drive API can often return `<br>` tags, causing the code block matching pattern to fail.

Additionally, requiring triple backticks to be immediately followed by newlines in a very rigid format can lead to unexpected behavior, where code blocks get treated as `code words` instead, leaving some backticks behind.

To simplify the use case for code blocks, this PR makes the matching pattern more lenient. It does this by changing a few things:
- The most basic code block matching only requires two sets of triple backticks, with any characters in between (line break optional)
- The syntax highlighting language is moved to a separate regex, which _does_ require a line break
- Any backticks (code words) within matched triple backticks (code blocks) are replaced with HTML escape sequences, so they do not create nested code blocks, which can mess up formatting.

While I was implementing this change, I also added a text-indent:0 to the `pre` styles, which fixes code block formatting within a list.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- ~[ ] tests are updated and/or added to cover new code~ (we should add some tests for the code formatting logic on arbitrary HTML snippets, perhaps in conjunction with #146)
- ~[ ] relevant documentation is changed and/or added~ n/a

