### PR TITLE
Add JSON responses

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -69,6 +69,15 @@ app.use((req, res, next) => {
   next()
 })
 
+// treat requests ending in .json as application/json
+app.use((req, res, next) => {
+  if (req.path.endsWith('.json')) {
+    req.headers.accept = 'application/json'
+    req.url = req.baseUrl + req.path.slice(0, -5)
+  }
+  next()
+})
+
 app.use(pages)
 app.use(cache)
 

--- a/server/routes/categories.js
+++ b/server/routes/categories.js
@@ -48,9 +48,17 @@ async function handleCategory(req, res) {
 
   // if this is a folder, just render from the generic data
   if (resourceType === 'folder') {
-    return res.render(template, baseRenderData, (err, html) => {
-      if (err) throw err
-      res.end(html)
+    return res.format({
+      html: () => {
+        res.render(template, baseRenderData, (err, html) => {
+          if (err) throw err
+          res.end(html)
+        })
+      },
+
+      json: () => {
+        res.json(baseRenderData)
+      }
     })
   }
 
@@ -58,14 +66,24 @@ async function handleCategory(req, res) {
   // for docs, fetch the html and then combine with the base data
   const {html, byline, createdBy, sections} = await fetchDoc(id, resourceType, req)
 
-  res.render(template, Object.assign({}, baseRenderData, {
+  const renderData = Object.assign({}, baseRenderData, {
     content: html,
     byline,
     createdBy,
     sections
-  }), (err, html) => {
-    if (err) throw err
-    res.end(html)
+  })
+
+  res.format({
+    html: () => {
+      res.render(template, renderData, (err, html) => {
+        if (err) throw err
+        res.end(html)
+      })
+    },
+
+    json: () => {
+      res.json(renderData)
+    }
   })
 }
 

--- a/server/routes/categories.js
+++ b/server/routes/categories.js
@@ -57,7 +57,8 @@ async function handleCategory(req, res) {
       },
 
       json: () => {
-        res.json(baseRenderData)
+        const {template, duplicates, ...jsonResponse} = Object.assign({}, baseRenderData, {resourceType})
+        res.json(jsonResponse)
       }
     })
   }
@@ -82,7 +83,8 @@ async function handleCategory(req, res) {
     },
 
     json: () => {
-      res.json(renderData)
+      const {template, duplicates, ...jsonResponse} = Object.assign({}, renderData, {resourceType})
+      res.json(jsonResponse)
     }
   })
 }

--- a/server/routes/errors.js
+++ b/server/routes/errors.js
@@ -63,9 +63,23 @@ module.exports = async (err, req, res, next) => {
   const code = messages[err.message] || 500
   log.error(`Serving an error page for ${req.url}`, err)
   const inlined = await loadInlineAssets()
-  res.status(code).render(`errors/${code}`, {
-    inlineCSS: inlined.css,
-    err,
-    template: inlined.stringTemplate
+  res.status(code)
+
+  res.format({
+    html: () => {
+      res.render(`errors/${code}`, {
+        inlineCSS: inlined.css,
+        err,
+        template: inlined.stringTemplate
+      })
+    },
+
+    json: () => {
+      res.json({
+        error: true,
+        code: code,
+        message: inlined.stringTemplate(`error.${code}.message`)
+      })
+    }
   })
 }

--- a/server/routes/pages.js
+++ b/server/routes/pages.js
@@ -10,7 +10,7 @@ const {getTemplates, sortDocs, stringTemplate, getConfig} = require('../utils')
 router.get('/', handlePage)
 router.get('/:page', handlePage)
 
-router.get('/filename-listing.json', async (req, res) => {
+router.get('/filename-listing', async (req, res) => {
   res.header('Cache-Control', 'public, must-revalidate') // override no-cache
   const filenames = await getFilenames()
   res.json({filenames: filenames})
@@ -38,7 +38,23 @@ async function handlePage(req, res) {
         if (exactMatches.length === 1) return res.redirect(exactMatches[0].path)
       }
 
-      res.render(template, {q, results, template: stringTemplate})
+      res.format({
+        html: () => {
+          res.render(template, {q, results, template: stringTemplate})
+        },
+
+        json: () => {
+          res.json(results.map((result) => ({
+            url: result.path,
+            title: result.prettyName,
+            lastUpdatedBy: (result.lastModifyingUser || {}).displayName,
+            modifiedAt: result.modifiedTime,
+            createdAt: result.createdTime,
+            id: result.id,
+            resourceType: result.resourceType
+          })))
+        }
+      })
     })
   }
 
@@ -47,7 +63,22 @@ async function handlePage(req, res) {
   if (page === 'categories' || page === 'index') {
     const tree = await getTree()
     const categories = buildDisplayCategories(tree)
-    res.render(template, {...categories, template: stringTemplate})
+    res.format({
+      html: () => {
+        res.render(template, {...categories, template: stringTemplate})
+      },
+
+      json: () => {
+        res.json(categories.all.map((category) => ({
+          url: category.path,
+          title: category.prettyName,
+          lastUpdatedBy: (category.lastModifyingUser || {}).displayName,
+          modifiedAt: category.modifiedTime,
+          createdAt: category.createdTime,
+          id: category.id
+        })))
+      }
+    })
     return
   }
 

--- a/server/routes/pages.js
+++ b/server/routes/pages.js
@@ -75,7 +75,8 @@ async function handlePage(req, res) {
           lastUpdatedBy: (category.lastModifyingUser || {}).displayName,
           modifiedAt: category.modifiedTime,
           createdAt: category.createdTime,
-          id: category.id
+          id: category.id,
+          resourceType: category.resourceType
         })))
       }
     })

--- a/test/functional/pages.test.js
+++ b/test/functional/pages.test.js
@@ -122,5 +122,42 @@ describe('Server responses', () => {
           expect(filenames.length).to.equal(allFilenames.length)
         })
     })
+
+    it('folder with home doc should render the doc', () => {
+      return request(app)
+        .get('/test-folder-9')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .then((res) => {
+          const data = JSON.parse(res.text)
+          expect(data).to.deep.equal(
+            {
+              html: '<p> This is a simple test document export.</p>',
+              byline: 'John Smith',
+              createdBy: 'John Smith',
+              sections: []
+            }
+          )
+        })
+    })
+
+    it('folder with home doc should render the doc (.json suffix)', () => {
+      return request(app)
+        .get('/test-folder-9.json')
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .then((res) => {
+          const data = JSON.parse(res.text)
+          expect(data).to.deep.equal(
+            {
+              html: '<p> This is a simple test document export.</p>',
+              byline: 'John Smith',
+              createdBy: 'John Smith',
+              sections: []
+            }
+          )
+        })
+    })
   })
 })

--- a/test/functional/pages.test.js
+++ b/test/functional/pages.test.js
@@ -113,7 +113,7 @@ describe('Server responses', () => {
   describe('that return JSON', () => {
     it('should contain a complete filename listing', () => {
       return request(app)
-      .get('/filename-listing.json')
+        .get('/filename-listing.json')
         .expect(200)
         .then((res) => {
           const {filenames} = res.body
@@ -131,9 +131,16 @@ describe('Server responses', () => {
         .expect('Content-Type', /json/)
         .then((res) => {
           const data = JSON.parse(res.text)
-          expect(data).to.deep.equal(
+          expect(data).to.deep.include(
             {
-              html: '<p> This is a simple test document export.</p>',
+              url: '/test-folder-9',
+              title: 'Home article 10 for test folder 9',
+              lastUpdatedBy: 'Foo Bar',
+              modifiedAt: '2018-03-02T14:13:20.000Z',
+              createdAt: '2018-02-19T00:26:40.000Z',
+              id: 'Test10',
+              resourceType: 'document',
+              content: '<p> This is a simple test document export.</p>',
               byline: 'John Smith',
               createdBy: 'John Smith',
               sections: []
@@ -149,9 +156,16 @@ describe('Server responses', () => {
         .expect('Content-Type', /json/)
         .then((res) => {
           const data = JSON.parse(res.text)
-          expect(data).to.deep.equal(
+          expect(data).to.deep.include(
             {
-              html: '<p> This is a simple test document export.</p>',
+              url: '/test-folder-9',
+              title: 'Home article 10 for test folder 9',
+              lastUpdatedBy: 'Foo Bar',
+              modifiedAt: '2018-03-02T14:13:20.000Z',
+              createdAt: '2018-02-19T00:26:40.000Z',
+              id: 'Test10',
+              resourceType: 'document',
+              content: '<p> This is a simple test document export.</p>',
               byline: 'John Smith',
               createdBy: 'John Smith',
               sections: []

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -8,6 +8,9 @@ const req = {url: 'foo.com/bar'}
 const res = {
   renderResults: {},
   status: () => res,
+  format: (formats) => {
+    formats.html()
+  },
   render: (template, opts) => { res.renderResults = {template, opts} }
 }
 


### PR DESCRIPTION
### Description of Change
Return HTML or JSON , with the format chosen to match the request accept
header.

Additionally, rewrite requests with URLs that end in ".json" to their
equivalent document without an extensnion but with the appropriate
accept header to receive a JSON response.

### Motivation and Context
I'd like to embed content from a Library instance in another product. Library is under active use and a different group of people manages its content than the team responsible for the product into which the Library content will be embedded. For maintainability, it's preferable to fetch that content from Library on the fly, and not be subject to the templating in Library.

### Checklist
- [X] Ran `npm run lint` and updated code style accordingly
- [X] `npm run test` passes
- [X] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added