### PR TITLE
WIP/RFC: Plugin Support

### DIFF
--- a/layouts/categories/default.ejs
+++ b/layouts/categories/default.ejs
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+  <%console.log(">>>>>>>>>>>>>>>>>>>", 'hi', locals.externalScripts) %>
   <%- include('partials/head') %>
   <body>
     <h1 class="visually-hidden">Default template</h1>

--- a/layouts/pages/index.ejs
+++ b/layouts/pages/index.ejs
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  <%- include('partials/head', {title: template('branding.prettyName')}) %>
+  <%- include('partials/head', {title: template('branding.prettyName'), externalScripts}) %>
   <body>
 
     <header id="masthead" class="masthead" role="banner">
@@ -18,11 +18,11 @@
         <%- include('partials/search', {style: 'homepage', focus: 'autofocus', msgOnFocus: template('search.placeholder')}) %>
 
         <div class="featured-cat">
-          <% if (modules.length) { 
+          <% if (modules.length) {
             modules.forEach((module, i, all) => {
           %>
             <%- include('partials/landingModule', module) %>
-          <%  })  
+          <%  })
           } else { %>
           <!-- Eventually we might display a warning here about why this space is empty. -->
           <% } %>

--- a/layouts/partials/head.ejs
+++ b/layouts/partials/head.ejs
@@ -19,6 +19,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
     <script src="/assets/scripts/main.js" charset="utf-8"></script>
   <% } %>
+  <% console.log('LOCALS', locals.externalScripts) %>
+  <% if (locals.externalScripts) { locals.externalScripts.forEach(scriptSrc => { %>
+    <script src="<%= scriptSrc %>"></script>
+  <% })} %>
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
   <link rel="shortcut icon" href="<%- template('branding.favicon') %>" type="image/x-icon" />
 </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@afischer/library-plugin-test": {
+      "version": "file:../../Desktop/library-plugin-test"
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -9621,7 +9624,7 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
@@ -9638,7 +9641,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "slugify": "^1.4.5",
     "unescape": "^1.0.1",
     "winston": "^2.4.5",
-    "xlsx": "^0.16.7"
+    "xlsx": "^0.16.7",
+    "@afischer/library-plugin-test": "file:~/Desktop/library-plugin-test"
   },
   "devDependencies": {
     "concurrently": "^5.2.0",

--- a/server/csp.js
+++ b/server/csp.js
@@ -1,0 +1,14 @@
+const {csps} = require('./plugins')
+
+const csp = {
+  defaultSrc: ["'self'", ...csps.flatMap((csp) => csp.defaultSrc || [])],
+  scriptSrc: ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com", "*.google-analytics.com", ...csps.flatMap((csp) => csp.scriptSrc || [])],
+  styleSrc: ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com", "fonts.googleapis.com", "maxcdn.bootstrapcdn.com", "*.googleusercontent.com", ...csps.flatMap((csp) => csp.styleSrc || [])],
+  fontSrc: ["'self'", "fonts.gstatic.com", "maxcdn.bootstrapcdn.com", ...csps.flatMap((csp) => csp.fontSrc || [])],
+  imgSrc: ["'self'", "data:", "*.googleusercontent.com", "*.google-analytics.com", ...csps.flatMap((csp) => csp.imgSrc || [])],
+  frameSrc: ["'self'","data:","*.youtube.com", ...csps.flatMap((csp) => csp.iframeSrc || [])],
+  objectSrc: ["'none'", ...csps.flatMap((csp) => csp.objectSrc || [])]
+}
+
+console.log(csp)
+module.exports = csp

--- a/server/csp.json
+++ b/server/csp.json
@@ -1,9 +1,0 @@
-{
-  "defaultSrc": ["'self'"],
-  "scriptSrc": ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com", "*.google-analytics.com"],
-  "styleSrc": ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com", "fonts.googleapis.com", "maxcdn.bootstrapcdn.com", "*.googleusercontent.com"],
-  "fontSrc": ["'self'", "fonts.gstatic.com", "maxcdn.bootstrapcdn.com"],
-  "imgSrc": ["'self'", "data:", "*.googleusercontent.com", "*.google-analytics.com"],
-  "frameSrc": ["'self'","data:","*.youtube.com"],
-  "objectSrc": ["'none'"]
-}

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -4,6 +4,7 @@ const qs = require('querystring')
 const unescape = require('unescape')
 const hljs = require('highlight.js')
 const list = require('./list')
+const {transforms} = require('./plugins');
 
 /* Your one stop shop for all your document processing needs. */
 
@@ -231,6 +232,7 @@ function getProcessedHtml(src) {
   let html = normalizeHtml(src)
   html = convertYoutubeUrl(html)
   html = formatCode(html)
+  transforms.forEach(transform => html = transform(html))
   html = pretty(html)
   return html
 }

--- a/server/plugins.js
+++ b/server/plugins.js
@@ -1,0 +1,22 @@
+const packageJson = require('../package.json')
+
+const transforms = []
+const scriptSrcs = []
+const csps = []
+
+Object.keys(packageJson.dependencies).forEach(depName => {
+  if (depName.includes('library-plugin')) {
+    console.log('>>', depName)
+    const {transform, externalScripts, csp} = require(depName)
+    transforms.push(transform)
+    scriptSrcs.push(...externalScripts)
+    csps.push(csp)
+  }
+})
+
+console.log(csps)
+module.exports = {
+  transforms,
+  externalScripts: scriptSrcs,
+  csps
+}

--- a/server/routes/categories.js
+++ b/server/routes/categories.js
@@ -7,6 +7,7 @@ const {getMeta} = require('../list')
 const {fetchDoc, cleanName} = require('../docs')
 const {getTemplates, sortDocs, stringTemplate} = require('../utils')
 const {parseUrl} = require('../urlParser')
+const {externalScripts} = require('../plugins')
 
 router.get('*', handleCategory)
 module.exports = router
@@ -43,7 +44,8 @@ async function handleCategory(req, res) {
     editLink: meta.mimeType === 'text/html' ? meta.folder.webViewLink : meta.webViewLink,
     id,
     template: stringTemplate,
-    duplicates
+    duplicates,
+    externalScripts
   })
 
   // if this is a folder, just render from the generic data


### PR DESCRIPTION
_Pushing this very WIP branch to develop out in the open and get comments/suggestions as this is built out!_

### Description of Change
<!-- Thanks for contributing! Please describe your addition and review the requirements below. Review the contributor's guide before submitting your pull request: https://github.com/nytimes/library/blob/master/CONTRIBUTING.md -->

Adds support for "zero config" plugins that are installed via npm, which can (at this point) do a few things:

- Export a `transform`, a function that can modify the HTML content
- Export a `csp` to extend the content security policy
- Export `externalScripts` to allow addition of additional scripts to the `<head>`
- More TK! Middleware? **Would love to hear your thoughts**

In the future, this feature could be expanded to 

### Related Issue
Closes #249


### Motivation and Context
See linked issue: It's currently somewhat cumbersome to add customizations to Library. People have used Docker-based solutions, or simply forked the repo in order to more easily get customizations added to the app.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [ ] Ran `npm run lint` and updated code style accordingly
- [ ] `npm run test` passes
- [ ] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

