### PR TITLE
Support a folder inside Team Drive

### DIFF
--- a/server/list.js
+++ b/server/list.js
@@ -92,7 +92,7 @@ function getOptions(id) {
   if (driveType === 'folder') {
     return {
       q: id.map((id) => `'${id}' in parents`).join(' or '),
-      corpora: "allDrives",
+      corpora: 'allDrives',
       includeItemsFromAllDrives: true,
       supportsAllDrives: true,
       fields,

--- a/server/list.js
+++ b/server/list.js
@@ -92,7 +92,11 @@ function getOptions(id) {
   if (driveType === 'folder') {
     return {
       q: id.map((id) => `'${id}' in parents`).join(' or '),
-      fields
+      corpora: "allDrives",
+      includeItemsFromAllDrives: true,
+      supportsAllDrives: true,
+      fields,
+      pageSize: 1000
     }
   }
 

--- a/server/list.js
+++ b/server/list.js
@@ -60,6 +60,22 @@ exports.getAllRoutes = () => {
     }, new Set())
 }
 
+exports.commonListOptions = {
+  folder: {
+    corpora: 'allDrives',
+    includeItemsFromAllDrives: true,
+    supportsAllDrives: true,
+    pageSize: 1000
+  },
+  team: {
+    q: 'trashed = false',
+    corpora: 'teamDrive',
+    supportsTeamDrives: true,
+    includeTeamDriveItems: true,
+    pageSize: 1000
+  }
+}
+
 // delay in ms, 15s default with env var
 const treeUpdateDelay = parseInt(process.env.LIST_UPDATE_DELAY || 15, 10) * 1000
 startTreeRefresh(treeUpdateDelay)
@@ -91,23 +107,16 @@ function getOptions(id) {
 
   if (driveType === 'folder') {
     return {
+      ...exports.commonListOptions.folder,
       q: id.map((id) => `'${id}' in parents`).join(' or '),
-      corpora: 'allDrives',
-      includeItemsFromAllDrives: true,
-      supportsAllDrives: true,
-      fields,
-      pageSize: 1000
+      fields
     }
   }
 
   return {
     teamDriveId: id,
-    q: 'trashed = false',
-    corpora: 'teamDrive',
-    supportsTeamDrives: true,
-    includeTeamDriveItems: true,
+    ...exports.commonListOptions.team,
     // fields: '*', // setting fields to '*' returns all fields but ignores pageSize
-    pageSize: 1000, // this value does not seem to be doing anything
     fields
   }
 }

--- a/server/search.js
+++ b/server/search.js
@@ -52,6 +52,7 @@ async function fullSearch({drive, query, folderIds, results = [], nextPageToken:
 // Grab all folders in directory to search through in shared drive
 async function getAllFolders({nextPageToken: pageToken, drive, parentIds = [driveId], foldersSoFar = []} = {}) {
   const options = {
+    ...list.commonListOptions.folder,
     q: `(${parentIds.map((id) => `'${id}' in parents`).join(' or ')}) AND mimeType = 'application/vnd.google-apps.folder'`,
     fields: 'files(id,name,mimeType,parents)'
   }
@@ -92,17 +93,16 @@ function getOptions(query, folderIds, driveType) {
   if (driveType === 'folder') {
     const parents = folderIds.map((id) => `'${id}' in parents`).join(' or ')
     return {
+      ...list.commonListOptions.folder,
       q: `(${parents}) AND fullText contains ${JSON.stringify(query)} AND mimeType != 'application/vnd.google-apps.folder' AND trashed = false`,
       fields
     }
   }
 
   return {
+    ...list.commonListOptions.team,
     q: `fullText contains ${JSON.stringify(query)} AND mimeType != 'application/vnd.google-apps.folder' AND trashed = false`,
     teamDriveId: driveId,
-    corpora: 'teamDrive',
-    supportsTeamDrives: true,
-    includeTeamDriveItems: true,
     fields
   }
 }


### PR DESCRIPTION
### Description of Change

Minor fix to make a Folder inside a Team Drive work as the DRIVE_ID. 

### Related Issue

In #270 I was wondering whether this is a supported scenario. 

### Motivation and Context

For completeness' sake -  if a Folder is supported as the root, there's no reason not to support a folder inside a Team Drive as well.

### Checklist

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes

Note: something wrong with docs.test.js on my machine, even in the `main` branch:

```
 FAIL  test/unit/docs.test.js
  ● Test suite failed to run

    Call retries were exceeded
```

- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code

Note: did not find a related test case to this functionality. I did, however, test manually that all these scenarios work
1. Team drive as root
2. Folder inside Team drive as root
3. Folder inside a personal drive as root

- [x] relevant documentation is changed and/or added

Note: Didn't find related documentation to change