### PR TITLE
remove filter by slug key

### DIFF
--- a/server/routes/categories.js
+++ b/server/routes/categories.js
@@ -94,12 +94,10 @@ function prepareContextualData(data, url, breadcrumb, parent, slug) {
 
   const {children: siblings} = parent
   const {children} = data
-  const self = url.split('/').slice(-1)[0]
   // most of what we are doing here is preparing parents and siblings
   // we need the url and parent object, as well as the breadcrumb to do that
-  const siblingLinks = createRelatedList(siblings, self, `${url.split('/').slice(0, -1).join('/')}`)
-  const childrenLinks = createRelatedList(children || {}, self, url)
-
+  const siblingLinks = createRelatedList(siblings)
+  const childrenLinks = createRelatedList(children || {})
   // extend the breadcrumb with render data
   const parentLinks = url
     .split('/')
@@ -121,9 +119,8 @@ function prepareContextualData(data, url, breadcrumb, parent, slug) {
   }
 }
 
-function createRelatedList(slugs, self, baseUrl) {
+function createRelatedList(slugs) {
   return Object.keys(slugs)
-    .filter((slug) => slug !== self)
     .map((slug) => {
       const {id} = slugs[slug]
       const {sort, prettyName, webViewLink, path: url, resourceType, tags} = getMeta(id)


### PR DESCRIPTION
### Description of Change
We had a bug where any document that shared a name with the parent folder was not visible in the document tree. We were filtering by the slug, which was the same as the parent. We removed this filter, and the child items are now visible. 

### Related Issue
#253 

### Motivation and Context
see above.

### Checklist

- [x] Ran `npm run lint` and updated code style accordingly
- [ ] `npm run test` passes
- [ ] PR has a description and all contributors/stakeholder are noted/cc'ed
- [] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

