### PR TITLE
Support diacritics in slug

### DIFF
--- a/server/docs.js
+++ b/server/docs.js
@@ -23,7 +23,7 @@ exports.cleanName = (name = '') => {
 
 exports.slugify = (text = '') => {
   // convert non alpha numeric into whitespace, rather than removing
-  const alphaNumeric = text.replace(/[^\w\d]/g, ' ')
+  const alphaNumeric = text.replace(/[^\p{L}\p{N}]+/ug, ' ')
   return slugify(alphaNumeric, {
     lower: true
   })

--- a/test/unit/docs.test.js
+++ b/test/unit/docs.test.js
@@ -60,6 +60,10 @@ describe('Docs', () => {
     it('should strip spacing', () => {
       expect(slugify('  slugify-  me please ')).equals('slugify-me-please')
     })
+
+    it('should support diacritics', () => {
+      expect(slugify('Öğretmenelere Öneriler')).equals('ogretmenelere-oneriler')
+    })
   })
 
   describe('Fetching Docs', () => {


### PR DESCRIPTION
### Description of Change
Previously, character with diacritics dissapear in slug. For example, "Öğretmenelere Öneriler" becomes "retmenelere-neriler". Now, with a change to the regex, slugify is able to use it's built in functionality of transforming diacritics to it's non diacritic counterparts ş -> s, ç -> c etc.

- Edited regex that goes into slugify function
- Added a test for diacritics in slug

### Related Issue
https://github.com/nytimes/library/issues/267

### Motivation and Context
Badly written slugs are a big issue for non-english internet and the links are less accessible.


### Checklist

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added

