### PR TITLE
Update install_customizations to prevent warnings

### DIFF
--- a/bin/install_customizations
+++ b/bin/install_customizations
@@ -10,7 +10,7 @@ if ! [[ -z ${CUSTOMIZATION_GIT_REPO} ]];
   then
     echo "Cloning custom repo...";
     # remove custom to allow for cloning to that directory name
-    rm -r ./custom;
+    rm -rf ./custom;
     git clone $CUSTOMIZATION_GIT_REPO custom;
     echo "Installing custom packages...";
     cd ./custom;


### PR DESCRIPTION
### Description of Change
<!-- Thanks for contributing! Please describe your addition and review the requirements below. Review the contributor's guide before submitting your pull request: https://github.com/nytimes/library/blob/master/CONTRIBUTING.md -->
Force-remove the customisation folder in order to prevent `rm` throwing `remove write-protected regular file` warning on Git objects under the `.git` directory.

### Related Issue
N/A

### Motivation and Context
When I was running the customisation script, I needed to manually say yes to all the `rm: remove write-protected regular file './custom/.git/objects/[...]'?` warnings, so I think this should fix it.

First PR here so please do correct me if I'm wrong about anything :)

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [ ] `npm run test` passes (it didn't pass even without my commit?)
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] ~~tests are updated and/or added to cover new code~~ (no need for new tests I reckon?)
- [ ] ~~relevant documentation is changed and/or added~~ (does not affect documentation)