### PR TITLE
Update install_customizations to remove duplicate directory

### DIFF
--- a/bin/install_customizations
+++ b/bin/install_customizations
@@ -19,6 +19,7 @@ if ! [[ -z ${CUSTOMIZATION_GIT_REPO} ]];
     yes | cp -rf ./node_modules/* ../node_modules;
     # copy custom images/assets
     yes | cp -rf ./public/* ../public;
+    rm -rf ./public
   else
     echo "Not found. Continuing with standard Library deploy";
 fi;


### PR DESCRIPTION
### Description of Change
<!-- Thanks for contributing! Please describe your addition and review the requirements below. Review the contributor's guide before submitting your pull request: https://github.com/nytimes/library/blob/master/CONTRIBUTING.md -->
Move & merge custom `public` directory instead of copying to save space.

### Related Issue
N/A

### Motivation and Context
The current script only copies the `public` directory, which means the files are still present in the `custom` directory. I have some files in the directory that takes up quite some space, so I think it would be better if the duplicate can be removed.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [ ] ~~`npm run test` passes~~ (shouldn't be relevant)
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] ~~tests are updated and/or added to cover new code~~ (no need for new tests)
- [ ] ~~relevant documentation is changed and/or added~~ (no need for new documentation)

I apologise if I've only been making minor changes (and to the bash script only). Gotta make some time to learn Node before I can contribute properly XD
