### PR TITLE
Update to only support LTS node versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - name: Check out repo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - 10
-  - 12
-before_script:
-  - npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:18
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/app.yaml
+++ b/app.yaml
@@ -1,2 +1,2 @@
-runtime: nodejs10
+runtime: nodejs18
 instance_class: F4

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "url": "https://github.com/nytimes/library/issues"
   },
   "engines": {
-    "node": ">=10.x",
-    "npm": ">=6.5.x"
+    "node": ">=14.x",
+    "npm": ">=6.14.x"
   },
   "homepage": "https://github.com/nytimes/library#readme"
 }


### PR DESCRIPTION
### Description of Change

Updates our package engines, CI and docker images to only use currently maintained versions of node.

### Related Issue
Closes #318

### Motivation and Context

In order to continue to maintain a stable, secure, and up-to-date app, it is necessary to drop older versions node as dependencies begin to drop support. Node 10 and 12 are [no longer being actively maintained](https://github.com/nodejs/Release#readme).

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added

