### PR TITLE
Datastore authentication for workload identity

### DIFF
--- a/server/routes/readingHistory.js
+++ b/server/routes/readingHistory.js
@@ -112,12 +112,20 @@ async function getDatastoreClient() {
   // because auth credentials may be passed in multiple ways, recycle pathway used by main auth logic
   const {email, key} = await getAuth()
 
-  return new Datastore({
-    projectId,
-    credentials: {
+  // When using workload identity, email and key will be missing. Passing
+  // blank credentials will block authentication, so leave these out so we can
+  // default to using the workload identity.
+  let credentials = {}
+  if (email && key) {
+    credentials = {
       client_email: email,
       private_key: key
     }
+  }
+
+  return new Datastore({
+    projectId,
+    ...credentials
   })
 }
 


### PR DESCRIPTION
### Description of Change
Fix authentication compatibility for datastore when using workload identity rather than manual credentials.

### Related Issue
N/A

### Motivation and Context
When using workload identity, `getAuth()` will return an object without `email` or `key` fields. If we provide null values when initialising the datastore client, this breaks authentication:

```
error: Serving an error page for /reading-history/teams.json?limit=5
message: 'The incoming JSON object does not contain a client_email field',
```

If instead we leave out any authentication details, the client will default to using the workload identity and successfully connect.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

