### PR TITLE
Set log level correctly

### DIFF
--- a/server/logger.js
+++ b/server/logger.js
@@ -12,6 +12,6 @@ const transports = process.env.NODE_ENV === 'test'
   ]
 
 module.exports = new (winston.Logger)({
-  level: process.env.LOG_LEVEL || process.env.NODE_ENV === 'development' ? 'debug' : 'info',
+  level: process.env.LOG_LEVEL || (process.env.NODE_ENV === 'development' ? 'debug' : 'info'),
   transports
 })

--- a/test/unit/logger.test.js
+++ b/test/unit/logger.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const {assert} = require('chai')
+
+describe('Logger', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    delete process.env.LOG_LEVEL
+    process.env.NODE_ENV = 'test'
+  })
+
+  it('initialises log level when specified in LOG_LEVEL', () => {
+    process.env.LOG_LEVEL = 'silly'
+    const logger = require('../../server/logger')
+    assert.equal(logger.level, 'silly')
+  })
+
+  it('initialises log level to debug in development', () => {
+    delete process.env.LOG_LEVEL
+    process.env.NODE_ENV = 'development'
+    const logger = require('../../server/logger')
+    assert.equal(logger.level, 'debug')
+  })
+
+  it('initialises log level to info in production', () => {
+    delete process.env.LOG_LEVEL
+    process.env.NODE_ENV = 'production'
+    const logger = require('../../server/logger')
+    assert.equal(logger.level, 'info')
+  })
+})


### PR DESCRIPTION
 ### Description of Change
The order of operations meant that previously when the LOG_LEVEL environment value was set, its value was ignored and instead we always set the log level to debug. This PR adds tests and fixes the bug.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

