### PR TITLE
Update Chai to v4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-cloud/datastore": "^5.1.0",
         "cache-manager": "^3.3.0",
-        "chai": "^4.4.1",
+        "chai": "^4.5.0",
         "cheerio": "^1.0.0-rc.3",
         "deepmerge": "^4.2.2",
         "ejs": "^3.1.7",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@google-cloud/datastore": "^5.1.0",
     "cache-manager": "^3.3.0",
-    "chai": "^4.4.1",
+    "chai": "^4.5.0",
     "cheerio": "^1.0.0-rc.3",
     "deepmerge": "^4.2.2",
     "ejs": "^3.1.7",


### PR DESCRIPTION
Updates the Chai assertion library to the [latest stable v4 release](https://github.com/chaijs/chai/releases/tag/v4.5.0).

Should also resolve https://github.com/nytimes/library/pull/371.