### PR TITLE
Rework Sass imports to use new dart sass style

### DIFF
--- a/styles/errors.scss
+++ b/styles/errors.scss
@@ -4,15 +4,15 @@
 // the authentication layer.)
 
 // top level templating values that can be overridden
-@use "partials/vars";
-@use "partials/theme";
+@use "vars" as *;
+@use "theme" as *;
 
 // core layout styles rarely overridden
-@use "partials/core/mixins";
-@use "partials/core/base";
-@use "partials/core/furniture";
-@use "partials/core/pages";
-@use "partials/core/categories";
+@use "core/mixins" as *;
+@use "core/base" as *;
+@use "core/furniture" as *;
+@use "core/pages" as *;
+@use "core/categories" as *;
 
 // final stylesheet with any additional styles for custom logic
-@use "partials/custom";
+@use "custom" as *;

--- a/styles/partials/_theme.scss
+++ b/styles/partials/_theme.scss
@@ -1,4 +1,4 @@
-@use "vars";
+@use "vars" as *;
 
 // Fonts
 //------------------------------------------------------------------------------
@@ -12,23 +12,23 @@ $font-sans: 'Open Sans', sans-serif;
 // Colors
 //------------------------------------------------------------------------------
 // Default Light Theme
-$masthead-background: vars.$gray-10;
-$main-homepage-background: vars.$white;
-$main-homepage-icon-color: vars.$black;
-$main-homepage-icon-border: vars.$black;
-$main-page-text-color: vars.$gray-35;
-$main-page-btn-color: vars.$gray-45;
+$masthead-background: $gray-10;
+$main-homepage-background: $white;
+$main-homepage-icon-color: $black;
+$main-homepage-icon-border: $black;
+$main-page-text-color: $gray-35;
+$main-page-btn-color: $gray-45;
 $search-container-background: #e6e2e2;
-$search-container-hover: vars.$gray-70;
-$btn-homepage-background: vars.$white;
-$btn-homepage-border: vars.$black;
-$btn-default-background: vars.$white;
-$btn-default-background-hover: vars.$accent;
-$btn-default-border: vars.$black;
-$btn-default-text-color: vars.$black;
-$btn-default-text-hover: vars.$black;
-$btn-user-initial: vars.$gray-50;
-$elem-link-color: vars.$gray-50;
-$elem-active-link-color: vars.$gray-50;
-$elem-link-accent: vars.$accent;
-$nav-text-color: vars.$gray-40;
+$search-container-hover: $gray-70;
+$btn-homepage-background: $white;
+$btn-homepage-border: $black;
+$btn-default-background: $white;
+$btn-default-background-hover: $accent;
+$btn-default-border: $black;
+$btn-default-text-color: $black;
+$btn-default-text-hover: $black;
+$btn-user-initial: $gray-50;
+$elem-link-color: $gray-50;
+$elem-active-link-color: $gray-50;
+$elem-link-accent: $accent;
+$nav-text-color: $gray-40;

--- a/styles/partials/core/_base.scss
+++ b/styles/partials/core/_base.scss
@@ -1,11 +1,11 @@
-@use "../theme";
-@use "../vars";
+@use "theme" as *;
+@use "vars" as *;
 @use "mixins";
 
 // Basic Styling
 //------------------------------------------------------------------------------
 body {
-  font-family: theme.$font-sans;
+  font-family: $font-sans;
   font-weight: 100;
   margin: 0;
   padding: 0;
@@ -16,13 +16,13 @@ pre {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: theme.$font-sans;
+  font-family: $font-sans;
   margin-top: 45px;
   margin-bottom: 20px;
 }
 
 a {
-  color: vars.$accent;
+  color: $accent;
   text-decoration: none;
 
   &:hover {
@@ -44,7 +44,7 @@ table {
 th, td {
   padding: 0.25rem 0.5rem;
   text-align: left;
-  border: 1px solid vars.$gray-50;
+  border: 1px solid $gray-50;
   p {
     margin: 0;
   }
@@ -69,14 +69,14 @@ button:focus {
   line-height: 18px;
   font-weight: 300;
   font-style: normal;
-  font-family: theme.$font-sans;
+  font-family: $font-sans;
   background-color: transparent;
   border-radius: 3px;
   transition: background-color 0.3s;
   display: inline-block;
   padding: 4px 8px 6px 8px;
-  border: 1px solid theme.$btn-default-border;
-  color: theme.$btn-default-text-color;
+  border: 1px solid $btn-default-border;
+  color: $btn-default-text-color;
   cursor: pointer;
 
   @include mixins.tablet{
@@ -92,7 +92,7 @@ button:focus {
 }
 
 .button.btn-cat {
-  background: theme.$btn-default-background;
+  background: $btn-default-background;
   border-radius: 0;
   margin: 4px 0 0 0;
   -webkit-font-smoothing: antialiased;
@@ -106,8 +106,8 @@ button:focus {
 
   &:hover {
     cursor: pointer;
-    background: theme.$btn-default-background-hover;
-    color: theme.$btn-default-text-hover;
+    background: $btn-default-background-hover;
+    color: $btn-default-text-hover;
     text-decoration: none;
   }
 }
@@ -116,21 +116,21 @@ button:focus {
   margin: 10px 0 0 0;
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
-  background-color: theme.$btn-homepage-background;
-  border: 1px solid theme.$btn-homepage-border;
+  background-color: $btn-homepage-background;
+  border: 1px solid $btn-homepage-border;
   border-radius: 0;
-  color: theme.$main-page-btn-color;
-  -webkit-box-shadow: 2.5px 2.5px 0px -1px vars.$accent-dark;
-  -moz-box-shadow: 2.5px 2.5px 0px -1px vars.$accent-dark;
-  box-shadow: 2.5px 2.5px 0px -1px vars.$accent-dark;
+  color: $main-page-btn-color;
+  -webkit-box-shadow: 2.5px 2.5px 0px -1px $accent-dark;
+  -moz-box-shadow: 2.5px 2.5px 0px -1px $accent-dark;
+  box-shadow: 2.5px 2.5px 0px -1px $accent-dark;
   padding: 5px 12px;
 
   &:hover {
-    background: theme.$elem-link-accent;
-    color: vars.$white;
-    -webkit-box-shadow: 3px 3px 0px 0px vars.$gray-25;
-    -moz-box-shadow: 3px 3px 0px 0px vars.$gray-25;
-    box-shadow: 3px 3px 0px 0px vars.$gray-25;
+    background: $elem-link-accent;
+    color: $white;
+    -webkit-box-shadow: 3px 3px 0px 0px $gray-25;
+    -moz-box-shadow: 3px 3px 0px 0px $gray-25;
+    box-shadow: 3px 3px 0px 0px $gray-25;
     text-decoration: none;
   }
 }
@@ -140,24 +140,24 @@ button:focus {
   line-height: 20px;
   font-weight: 400;
   font-style: normal;
-  font-family: theme.$font-sans;
+  font-family: $font-sans;
   background-color: transparent;
   transition: background-color 0.3s;
   display: inline-block;
   padding: 7px 10px;
-  border: 1px solid vars.$gray-40;
+  border: 1px solid $gray-40;
   cursor: pointer;
   -webkit-font-smoothing: antialiased;
-  -webkit-box-shadow: 5px 5px 0px 0px vars.$offwhite;
-  -moz-box-shadow: 5px 5px 0px 0px vars.$offwhite;
-  box-shadow: 5px 5px 0px 0px vars.$offwhite;
+  -webkit-box-shadow: 5px 5px 0px 0px $offwhite;
+  -moz-box-shadow: 5px 5px 0px 0px $offwhite;
+  box-shadow: 5px 5px 0px 0px $offwhite;
   margin-right: 10px;
-  color: vars.$gray-20;
+  color: $gray-20;
   margin-top: 10px;
 
   &:hover {
-    background: vars.$gray-20;
-    color: vars.$white;
+    background: $gray-20;
+    color: $white;
   }
 }
 
@@ -165,12 +165,12 @@ button:focus {
   border: none;
   text-decoration: underline;
   background: transparent;
-  color: theme.$nav-text-color;
+  color: $nav-text-color;
   font-size: 13px;
   line-height: 29px;
 
   &:hover {
     cursor: pointer;
-    color: vars.$accent;
+    color: $accent;
   }
 }

--- a/styles/partials/core/_categories.scss
+++ b/styles/partials/core/_categories.scss
@@ -1,5 +1,5 @@
-@use "../theme";
-@use "../vars";
+@use "theme" as *;
+@use "vars" as *;
 @use "mixins";
 
 
@@ -18,18 +18,18 @@
 
   .warning {
     margin-top: 10px;
-    background-color: vars.$gray-50;
-    color: vars.$black;
+    background-color: $gray-50;
+    color: $black;
     padding: 15px;
     font-size: 14px;
   }
 
   h1.headline {
-    font-family: theme.$font-headline;
+    font-family: $font-headline;
     font-size: 36px;
     line-height: 40px;
     font-weight: 200;
-    color: vars.$black;
+    color: $black;
     margin: 20px 0 5px;
 
     @include mixins.tablet {
@@ -53,9 +53,9 @@
 
   .attribution {
     p {
-      font-family: theme.$font-sans;
+      font-family: $font-sans;
       font-size: 13px;
-      color: theme.$nav-text-color;
+      color: $nav-text-color;
       margin: 0;
       line-height: 18px;
       font-weight: 400;
@@ -72,18 +72,18 @@
     font-weight: 400;
 
     a {
-      color: vars.$gray-40;
+      color: $gray-40;
       text-decoration: underline;
       .fa {
         margin-left: 5px;
-        color: vars.$gray-40;
+        color: $gray-40;
       }
     }
 
     a:hover {
-      color: vars.$accent;
+      color: $accent;
       .fa {
-        color: vars.$accent;
+        color: $accent;
       }
     }
 
@@ -130,10 +130,10 @@
     }
 
     .section-kicker, .sibling-kicker {
-      font-family: theme.$font-sans;
+      font-family: $font-sans;
       font-weight: 600;
       text-transform: capitalize;
-      color: vars.$black;
+      color: $black;
       font-size: 14px;
       line-height: 24px;
       margin-bottom: 10px;
@@ -157,7 +157,7 @@
         line-height: 20px;
         text-indent: -4px;
         padding: 4px 0px;
-        border-bottom: 0.5px solid vars.$gray-60;
+        border-bottom: 0.5px solid $gray-60;
         font-weight: 400;
 
         &:last-child {
@@ -167,11 +167,11 @@
         a,
         strong {
           padding: 3px 5px;
-          color: vars.$gray-20;
+          color: $gray-20;
         }
 
         a:hover {
-          color: vars.$accent;
+          color: $accent;
         }
 
       }
@@ -181,7 +181,7 @@
       list-style-type: none;
       margin: 40px 0 40px 0;
       padding: 20px;
-      border: 1px solid vars.$gray-60;
+      border: 1px solid $gray-60;
       -webkit-box-shadow: -8px -8px 0px 0px rgba(236,236,236,1);
       -moz-box-shadow: -8px -8px 0px 0px rgba(236,236,236,1);
       box-shadow: -8px -8px 0px 0px rgba(236,236,236,1);
@@ -203,7 +203,7 @@
 
         &:before {
           content: "";
-          border-bottom: 1px solid vars.$gray-50;
+          border-bottom: 1px solid $gray-50;
           width: 10px;
           display: inline-block;
           vertical-align: middle;
@@ -214,7 +214,7 @@
   }
 
   .g-main-content {
-    border-top: 5px solid vars.$gray-60;
+    border-top: 5px solid $gray-60;
   }
 
   .playlist-navigation,
@@ -229,7 +229,7 @@
     }
 
     p, ul, li, dt, dd {
-      font-family: theme.$font-sans;
+      font-family: $font-sans;
       font-weight: 300;
       font-size: 1rem;
       line-height: 1.4;
@@ -271,7 +271,7 @@
 
     img {
       max-width: calc(100vw - 80px);
-      border: 1px solid vars.$gray-60;
+      border: 1px solid $gray-60;
       padding: 10px;
       display: block;
       margin: 20px auto;
@@ -303,7 +303,7 @@
     .children-container {
       margin: 40px 0 40px 0;
       padding: 20px 0px 20px 40px;
-      border: 1px solid vars.$gray-60;
+      border: 1px solid $gray-60;
       -webkit-box-shadow: -4px -4px 0px 0px #efefef;
       -moz-box-shadow: -4px -4px 0px 0px #efefef;
       box-shadow: -4px -4px 0px 0px #efefef;
@@ -364,7 +364,7 @@
         box-sizing: border-box;
 
         a {
-          color: vars.$black;
+          color: $black;
         }
       }
     }
@@ -383,13 +383,13 @@
     }
 
     code {
-      background: vars.$accent-lightest;
-      color: vars.$accent-dark;
+      background: $accent-lightest;
+      color: $accent-dark;
       padding: 1px 0px;
       margin: 0 4px;
-      -webkit-box-shadow: 4px 0px 0px vars.$accent-lightest, -4px 0px 0px vars.$accent-lightest;
-      -moz-box-shadow: 4px 0px 0px vars.$accent-lightest, -4px 0px 0px vars.$accent-lightest;
-      box-shadow: 4px 0px 0px vars.$accent-lightest, -4px 0px 0px vars.$accent-lightest;
+      -webkit-box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
+      -moz-box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
+      box-shadow: 4px 0px 0px $accent-lightest, -4px 0px 0px $accent-lightest;
       -webkit-box-decoration-break: clone;
       -moz-box-decoration-break: clone;
       box-decoration-break: clone;
@@ -397,7 +397,7 @@
 
     pre{
       counter-reset:line-numbering;
-      background: vars.$accent-lightest;
+      background: $accent-lightest;
       padding: 0px 0px 20px 0;
       width: 600px;
       text-indent: 0;
@@ -422,7 +422,7 @@
         width: 1.5em;
         text-align: right;
         opacity: 0.5;
-        color:vars.$gray-45;
+        color:$gray-45;
       }
 
       &:before {
@@ -431,7 +431,7 @@
         height: 20px;
         content: 'Code';
         background: #EEE9E9;
-        color:vars.$gray-45;
+        color:$gray-45;
         padding-left: 10px;
         margin-bottom: 10px;
         margin-top: 20px;
@@ -441,7 +441,7 @@
       code {
         margin: 0;
         padding: 0;
-        color: vars.$black;
+        color: $black;
       }
     }
   }
@@ -463,7 +463,7 @@
           // color: #483d8b;
           // padding: 3px 7px;
           // font-weight: 400;
-          background: vars.$gray-80;
+          background: $gray-80;
           color: #666;
           padding: 3px 6px;
           font-weight: 400;
@@ -474,8 +474,8 @@
           text-decoration: none;
 
           span {
-            background: vars.$accent-lightest;
-            color: vars.$black;
+            background: $accent-lightest;
+            color: $black;
           }
         }
       }
@@ -503,7 +503,7 @@
   .g-footer {
     max-width: 600px;
     margin: 80px auto 60px auto;
-    border-top: 1px solid vars.$gray-50;
+    border-top: 1px solid $gray-50;
     padding: 20px 0px;
 
     .button.btn-plaintext {
@@ -511,7 +511,7 @@
     }
 
     p {
-      font-family: theme.$font-sans;
+      font-family: $font-sans;
       font-weight: 300;
       font-size: 14px;
       line-height: 18px;

--- a/styles/partials/core/_furniture.scss
+++ b/styles/partials/core/_furniture.scss
@@ -1,5 +1,5 @@
-@use "../theme";
-@use "../vars";
+@use "theme" as *;
+@use "vars" as *;
 @use "mixins";
 @use "sass:color";
 
@@ -7,12 +7,12 @@
 //------------------------------------------------------------------------------
 .masthead {
   position: fixed;
-  background: theme.$masthead-background;
+  background: $masthead-background;
   top: 0;
   left: 0;
   width: 100vw;
   z-index: 1000000090;
-  color: theme.$elem-link-color;
+  color: $elem-link-color;
 
   .container {
     position: relative;
@@ -43,8 +43,8 @@
         padding: 4px 0 0 15px;
         vertical-align: top;
         border-left: 1px solid rgba(255, 255, 255, 0.35);
-        color: theme.$main-homepage-icon-border;
-        font-family: theme.$font-branding;
+        color: $main-homepage-icon-border;
+        font-family: $font-branding;
         font-size: 18px;
         text-transform: none;
         -webkit-font-smoothing: antialiased;
@@ -52,10 +52,10 @@
         line-height: 26px;
 
         a:link, a:visited {
-          color: theme.$elem-link-color;
+          color: $elem-link-color;
         }
         a:hover {
-          color: vars.$accent;
+          color: $accent;
           cursor: pointer;
           text-decoration: none;
         }
@@ -110,12 +110,12 @@
   }
 
   a:visited {
-      color: vars.$accent-light;
+      color: $accent-light;
   }
 
   a:link {
       text-decoration: none;
-      color: vars.$accent-light;
+      color: $accent-light;
   }
 }
 
@@ -135,7 +135,7 @@
 
   .tt-menu {
     background-color: inherit;
-    border-color: vars.$gray-40;
+    border-color: $gray-40;
     border-style: solid;
     border-width: 0 1px 1px 1px;
     // compensate for border
@@ -150,17 +150,17 @@
     cursor: pointer;
 
     &:hover {
-      background-color: vars.$accent-light;
+      background-color: $accent-light;
     }
   }
 
   .tt-cursor {
-    background-color: vars.$accent-light;
+    background-color: $accent-light;
   }
 
   .twitter-typeahead {
     font-style: normal;
-    font-family: theme.$font-sans;
+    font-family: $font-sans;
     font-size: 16px;
     line-height: 30px;
     font-weight: 400;
@@ -169,12 +169,12 @@
     height: 50px;
     transition: background-color 0.3s;
     display: inline-block;
-    border: 1px solid vars.$gray-40;
-    background: vars.$white;
-    -webkit-box-shadow: 5px 5px 0px 0px vars.$gray-25;;
-    -moz-box-shadow: 5px 5px 0px 0px vars.$gray-25;;
-    box-shadow: 5px 5px 0px 0px vars.$gray-25;;
-    color: vars.$black;
+    border: 1px solid $gray-40;
+    background: $white;
+    -webkit-box-shadow: 5px 5px 0px 0px $gray-25;;
+    -moz-box-shadow: 5px 5px 0px 0px $gray-25;;
+    box-shadow: 5px 5px 0px 0px $gray-25;;
+    color: $black;
     float: left;
     width: calc(100% - 20px);
     -webkit-transition: background .55s ease;
@@ -189,12 +189,12 @@
     &:focus,
     &:active {
       outline: none;
-      background:  vars.$accent-lightest;
+      background:  $accent-lightest;
     }
 
 
     .tt-hint {
-      color: vars.$gray-30;
+      color: $gray-30;
       background-color: transparent !important;
       outline: none;
       border: none;
@@ -215,12 +215,12 @@
     position: relative;
     z-index: 10;
     border: none;
-    background: vars.$accent;
+    background: $accent;
     height: 50px;
     width: 50px;
     top: 1px; // compensate for top border
     right: 1px; // compensate for right border
-    color: vars.$white;
+    color: $white;
     opacity: 1;
     font-size: 12pt;
     cursor: pointer;
@@ -234,14 +234,14 @@
 
   &:hover {
     .icon:hover {
-      background: vars.$accent;
+      background: $accent;
     }
   }
 
   input::-webkit-input-placeholder,
   input:-moz-placeholder,
   input:-ms-input-placeholder  {
-    color: vars.$gray-45;
+    color: $gray-45;
   }
   input:focus::-webkit-input-placeholder,
   input:focus:-moz-placeholder,
@@ -263,19 +263,19 @@
 #user-profile {
   a.btn-user-whole {
     &:link, &:visited {
-      color: theme.$elem-link-color;
+      color: $elem-link-color;
       font-size: 15px;
       letter-spacing: 0.25px;
       padding: 17px 15px 16px 15px;
     }
     &:hover, &:active, &:target {
       text-decoration: none;
-      background: color.scale(theme.$elem-active-link-color, $lightness: -30%);
+      background: color.scale($elem-active-link-color, $lightness: -30%);
 
       button.btn-user-initial {
-        background: vars.$black;
-        color: vars.$gray-50;
-        border-color: vars.$gray-30;
+        background: $black;
+        color: $gray-50;
+        border-color: $gray-30;
       }
     }
   }
@@ -300,12 +300,12 @@
     font-size: 14px;
     -webkit-font-smoothing: antialiased;
     text-indent: -1px;
-    background: theme.$btn-user-initial;
-    color: vars.$gray-30;
+    background: $btn-user-initial;
+    color: $gray-30;
     margin-right: 5px;
     line-height: 0px;
     text-align: center;
-    border-color: vars.$gray-80;
+    border-color: $gray-80;
     padding: 0;
   }
 }
@@ -341,7 +341,7 @@
 .popup {
   margin-top: 40px;
 	padding: 0 20px 5px 20px;
-  background-image: linear-gradient(215deg, vars.$white 0%, vars.$offwhite 100%);
+  background-image: linear-gradient(215deg, $white 0%, $offwhite 100%);
 	border: 1px solid #d4d4d4;
 	width: 260px;
   float: right;
@@ -367,7 +367,7 @@
     font-size: 24px;
     font-weight: bold;
     text-decoration: none;
-    color: vars.$gray-30;
+    color: $gray-30;
     &:hover {
       opacity: 1;
     }
@@ -375,8 +375,8 @@
 
   h3 {
     margin: 10px auto 0px auto;
-    color: vars.$gray-20;
-    border-bottom: 2px solid vars.$gray-20;
+    color: $gray-20;
+    border-bottom: 2px solid $gray-20;
     font-size: 16px;
     line-height: 30px;
     -webkit-font-smoothing: antialiased;
@@ -398,13 +398,13 @@
 
     li {
       a {
-        color: vars.$gray-20;
+        color: $gray-20;
 
         &:hover {
           text-decoration: none;
 
           p {
-            color: vars.$black;
+            color: $black;
           }
         }
       }
@@ -419,7 +419,7 @@
       }
 
       .docs-title {
-        color: vars.$accent;
+        color: $accent;
         margin-bottom: 2px;
       }
 
@@ -430,8 +430,8 @@
         display: inline-block;
         margin-right: 4px;
         // background: if($light, $gray-60, $gray-80);
-        background: theme.$elem-link-color; // gray-50 and grey-80
-        color: vars.$gray-30;
+        background: $elem-link-color; // gray-50 and grey-80
+        color: $gray-30;
         padding: 3px 4px;
         font-weight: 400;
         font-size: 12px;
@@ -443,7 +443,7 @@
       }
       .timestamp {
         font-size: 12px;
-        color: vars.$gray-30;
+        color: $gray-30;
       }
     }
   }

--- a/styles/partials/core/_mixins.scss
+++ b/styles/partials/core/_mixins.scss
@@ -1,3 +1,5 @@
+@use "vars" as *;
+
 $tablet-width: 768px;
 $smalldesktop-width: 960px;
 $desktop-width: 1024px;

--- a/styles/partials/core/_pages.scss
+++ b/styles/partials/core/_pages.scss
@@ -1,11 +1,11 @@
-@use "../theme";
-@use "../vars";
+@use "theme" as *;
+@use "vars" as *;
 @use "mixins";
 
 // Main Homepage
 //------------------------------------------------------------------------------
 #main-search-page {
-  background: theme.$main-homepage-background;
+  background: $main-homepage-background;
   padding: 85px 20px 3px 20px;
   min-height: calc(100vh - 88px);
 
@@ -64,9 +64,9 @@
         margin: 0 0 0 15px;
         height: 21px;
         padding: 10px 0 10px 15px;
-        border-left: 1px solid theme.$main-homepage-icon-border;
-        color: theme.$main-homepage-icon-color;
-        font-family: theme.$font-branding;
+        border-left: 1px solid $main-homepage-icon-border;
+        color: $main-homepage-icon-color;
+        font-family: $font-branding;
         font-size: 28px;
         font-weight: 100;
         line-height: 21px;
@@ -89,10 +89,10 @@
         }
 
         a:link, a:visited {
-          color: vars.$gray-50;
+          color: $gray-50;
         }
         a:hover {
-          color: vars.$accent;
+          color: $accent;
           text-decoration: none;
         }
       }
@@ -100,7 +100,7 @@
 
     .tagline {
       text-align: center;
-      color: theme.$main-page-text-color;
+      color: $main-page-text-color;
       margin: 0 auto;
       margin-bottom: 60px;
       font-size: 14px;
@@ -137,11 +137,11 @@
     	}
 
       .twitter-typeahead {
-        background: theme.$search-container-background;
+        background: $search-container-background;
         &:hover,
         &:focus,
         &:active {
-          background: theme.$search-container-hover;
+          background: $search-container-hover;
         }
       }
 
@@ -160,7 +160,7 @@
 
       &:hover {
         .icon:hover {
-          background: vars.$accent;
+          background: $accent;
         }
       }
     }
@@ -201,7 +201,7 @@
         h3 {
           font-weight: normal;
           font-size: 14px;
-          color: theme.$main-page-text-color;
+          color: $main-page-text-color;
           margin: 15px 0;
 
           @include mixins.tablet{
@@ -241,7 +241,7 @@
           ul {
             padding-left: 7px;
             a {
-              color: theme.$btn-default-text-color;
+              color: $btn-default-text-color;
               -webkit-font-smoothing: antialiased;
             }
             li {
@@ -255,7 +255,7 @@
               }
 
               .fa {
-                color: theme.$main-homepage-icon-color;
+                color: $main-homepage-icon-color;
                 margin-right: 7px;
                 font-size: 14px;
                 line-height: 18px;
@@ -281,20 +281,20 @@
     }
 
     .help-text {
-      color: theme.$main-page-text-color;
+      color: $main-page-text-color;
       font-size: 14px;
       line-height: 21px;
       letter-spacing: 0;
       text-align: left;
 
       a {
-        color: theme.$main-page-text-color;
-        border-bottom: 1px solid theme.$main-page-text-color;
+        color: $main-page-text-color;
+        border-bottom: 1px solid $main-page-text-color;
         padding-bottom: 1px;
 
         &:hover {
-          color: theme.$elem-link-color;
-          border-bottom: 1px solid theme.$elem-link-color;
+          color: $elem-link-color;
+          border-bottom: 1px solid $elem-link-color;
           text-decoration: none;
         }
       }
@@ -343,15 +343,15 @@
       border: 1px solid #404040;
       border-radius: 0;
       color: black;
-      -webkit-box-shadow: 2.5px 2.5px 0px -1px vars.$gray-25;
-      -moz-box-shadow: 2.5px 2.5px 0px -1px vars.$gray-25;
-      box-shadow: 2.5px 2.5px 0px -1px vars.$gray-25;
+      -webkit-box-shadow: 2.5px 2.5px 0px -1px $gray-25;
+      -moz-box-shadow: 2.5px 2.5px 0px -1px $gray-25;
+      box-shadow: 2.5px 2.5px 0px -1px $gray-25;
       padding: 5px 12px;
       cursor: pointer;
     }
 
     .seeMore-button:hover {
-      background-color: vars.$gray-60;
+      background-color: $gray-60;
     }
 
 
@@ -359,7 +359,7 @@
       overflow: visible;
       margin: 0 12px 30px 12px;
       padding: 25px;
-      border: 1px solid vars.$gray-60;
+      border: 1px solid $gray-60;
       width: 100%;
       -webkit-box-shadow: -4px -4px 0px 0px rgba(239,239,239,1);
       -moz-box-shadow: -4px -4px 0px 0px rgba(239,239,239,1);
@@ -398,7 +398,7 @@
           padding-right: 0;
 
           a {
-            color: vars.$black;
+            color: $black;
           }
         }
       }

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -1,13 +1,13 @@
 // top level templating values that can be overridden
-@use "partials/vars";
-@use "partials/theme";
+@use "vars" as *;
+@use "theme" as *;
 
 // core layout styles rarely overridden
-@use "partials/core/mixins";
-@use "partials/core/base";
-@use "partials/core/furniture";
-@use "partials/core/pages";
-@use "partials/core/categories";
+@use "core/mixins" as *;
+@use "core/base" as *;
+@use "core/furniture" as *;
+@use "core/pages" as *;
+@use "core/categories" as *;
 
 // final stylesheet with any additional styles for custom logic
-@use "partials/custom";
+@use "custom" as *;


### PR DESCRIPTION
### Description of Change
The 1.6.0 update included an update to node-sass to use `sass`, which is not deprecated. In updating the pathing to work with the new syntax, I inadvertently broke the ability for users to do custom overrides. This restores that functionality by updating the paths and moves to use the new global import syntax.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added

