### PR TITLE
Add special note for when files are too large to export

### DIFF
--- a/config/strings.yaml
+++ b/config/strings.yaml
@@ -22,7 +22,6 @@ landing:
       label: Useful Docs
       style: docs
 
-
 # partials/footer
 footer:
   helpText: Questions? Contact your organization's administrators.
@@ -65,7 +64,7 @@ playlist:
     heading: !!js/function (title) => `${title} Playlist`
   nav:
     previous: <
-    next: '>'
+    next: ">"
 
 # errors
 error:
@@ -81,8 +80,10 @@ error:
     title: Server Error
     heading: Uh oh, that's a 500.
     message: Perhaps try to search for something else instead?
+    sizeLimitNote:
+      message: "The document is too large to display in Library. We are working on a fix, but in the meantime, you can view the document directly in Google Drive."
+      viewButton: "View the document directly in Google Drive"
 
 # warning messages
 warning:
   duplicate: !!js/function (names, folderId) => `Multiple resources in <a href="https://drive.google.com/drive/u/0/folders/${folderId}" target="_blank">this folder</a> share the same name&#58; ${names.join(', ')}. Only one will be accesible through Library.`
-

--- a/layouts/errors/500.ejs
+++ b/layouts/errors/500.ejs
@@ -1,19 +1,32 @@
 <!DOCTYPE html>
 <html>
-  <%- include('partials/head', {title: template('error.500.title'), formatUrl, pathPrefix}) %>
+  <%- include('partials/head', {title: template('error.500.title'), formatUrl,
+  pathPrefix}) %>
   <body>
-    <%- include('partials/header', {title: template('error.500.title'), parentLinks: [], formatUrl}) %>
+    <%- include( 'partials/header', {title: template('error.500.title'),
+    parentLinks: [], formatUrl} ) %>
     <div id="main-search-page">
       <div class="main-item">
         <div class="tagline">
           <h1><%- template('error.500.heading') %></h1>
           <p><%- template('error.500.message') %></p>
+
+          <% if (err.errors && err.errors.find(error => error.reason ===
+          'exportSizeLimitExceeded')) { %>
+          <h3><%- template('error.500.sizeLimitNote.message') %></h3>
+          <a
+            href="https://docs.google.com/document/d/<%= locals.docId %>"
+            class="button btn-footer"
+            target="_blank"
+            rel="noopener noreferrer"
+            ><%- template('error.500.sizeLimitNote.viewButton') %></a
+          >
+          <% } %>
         </div>
         <%- include('partials/search', {style: 'homepage', formatUrl}) %>
       </div>
 
       <%- include('partials/footer', {style: 'homepage', formatUrl}) %>
     </div>
-
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "library",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "library",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/datastore": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A collaborative newsroom documentation site, powered by Google Docs.",
   "main": "server/index.js",
   "dependencies": {


### PR DESCRIPTION
### Description of Change

Adds a customizable message for when a page 500s due to a file being too large to export.

<img width="720" height="320" alt="image" src="https://github.com/user-attachments/assets/c30dc6c8-66fc-41c0-a4f1-0607d8230bad" />


### Related Issue

https://github.com/nytimes/library/issues/388

### Motivation and Context

This has been confusing for users, and will hopefully reduce support burden for those supporting Library as we work on fixing the issue.

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [x] Ran `npm run lint` and updated code style accordingly
- [x] `npm run test` passes
- [x] PR has a description and all contributors/stakeholder are noted/cc'ed
- [x] tests are updated and/or added to cover new code
- [x] relevant documentation is changed and/or added

